### PR TITLE
Issue #SB-9610 fix: pipeline job build optimization

### DIFF
--- a/data-pipeline/de-duplication/src/main/assembly/src.xml
+++ b/data-pipeline/de-duplication/src/main/assembly/src.xml
@@ -66,9 +66,5 @@
             </includes>
             <useTransitiveFiltering>true</useTransitiveFiltering>
         </dependencySet>
-        <dependencySet>
-            <outputDirectory>/</outputDirectory>
-            <unpack>false</unpack>
-        </dependencySet>
     </dependencySets>
 </assembly>

--- a/data-pipeline/es-indexer/src/main/assembly/src.xml
+++ b/data-pipeline/es-indexer/src/main/assembly/src.xml
@@ -66,9 +66,5 @@
             </includes>
             <useTransitiveFiltering>true</useTransitiveFiltering>
         </dependencySet>
-        <dependencySet>
-            <outputDirectory>/</outputDirectory>
-            <unpack>false</unpack>
-        </dependencySet>
     </dependencySets>
 </assembly>

--- a/data-pipeline/level-setting/src/main/assembly/src.xml
+++ b/data-pipeline/level-setting/src/main/assembly/src.xml
@@ -66,9 +66,5 @@
             </includes>
             <useTransitiveFiltering>true</useTransitiveFiltering>
         </dependencySet>
-        <dependencySet>
-            <outputDirectory>/</outputDirectory>
-            <unpack>false</unpack>
-        </dependencySet>
     </dependencySets>
 </assembly>

--- a/data-pipeline/object-de-normalization/src/main/assembly/src.xml
+++ b/data-pipeline/object-de-normalization/src/main/assembly/src.xml
@@ -66,9 +66,5 @@
             </includes>
             <useTransitiveFiltering>true</useTransitiveFiltering>
         </dependencySet>
-        <dependencySet>
-            <outputDirectory>/</outputDirectory>
-            <unpack>false</unpack>
-        </dependencySet>
     </dependencySets>
 </assembly>

--- a/data-pipeline/reverse-search/src/main/assembly/src.xml
+++ b/data-pipeline/reverse-search/src/main/assembly/src.xml
@@ -66,9 +66,5 @@
       </includes>
       <useTransitiveFiltering>true</useTransitiveFiltering>
     </dependencySet>
-    <dependencySet>
-      <outputDirectory>/</outputDirectory>
-      <unpack>false</unpack>
-    </dependencySet>
   </dependencySets>
 </assembly>

--- a/data-pipeline/telemetry-extractor/src/main/assembly/src.xml
+++ b/data-pipeline/telemetry-extractor/src/main/assembly/src.xml
@@ -66,9 +66,5 @@
             </includes>
             <useTransitiveFiltering>true</useTransitiveFiltering>
         </dependencySet>
-        <dependencySet>
-            <outputDirectory>/</outputDirectory>
-            <unpack>false</unpack>
-        </dependencySet>
     </dependencySets>
 </assembly>

--- a/data-pipeline/telemetry-location-updater/src/main/assembly/src.xml
+++ b/data-pipeline/telemetry-location-updater/src/main/assembly/src.xml
@@ -66,9 +66,5 @@
             </includes>
             <useTransitiveFiltering>true</useTransitiveFiltering>
         </dependencySet>
-        <dependencySet>
-            <outputDirectory>/</outputDirectory>
-            <unpack>false</unpack>
-        </dependencySet>
     </dependencySets>
 </assembly>

--- a/data-pipeline/telemetry-router/src/main/assembly/src.xml
+++ b/data-pipeline/telemetry-router/src/main/assembly/src.xml
@@ -66,9 +66,5 @@
             </includes>
             <useTransitiveFiltering>true</useTransitiveFiltering>
         </dependencySet>
-        <dependencySet>
-            <outputDirectory>/</outputDirectory>
-            <unpack>false</unpack>
-        </dependencySet>
     </dependencySets>
 </assembly>

--- a/data-pipeline/telemetry-validator/src/main/assembly/src.xml
+++ b/data-pipeline/telemetry-validator/src/main/assembly/src.xml
@@ -66,9 +66,5 @@
             </includes>
             <useTransitiveFiltering>true</useTransitiveFiltering>
         </dependencySet>
-        <dependencySet>
-            <outputDirectory>/</outputDirectory>
-            <unpack>false</unpack>
-        </dependencySet>
     </dependencySets>
 </assembly>


### PR DESCRIPTION
changes:
- removed dependencySet config from Maven assembly plugin. This was causing the build to have unnecessary jars in the root dir of the build