### PR TITLE
Issue #DO-587 feat: Add yarn.nodemanager.recovery.enabled flag to yarn-site.xml

### DIFF
--- a/ansible/roles/yarn/templates/yarn-site.xml
+++ b/ansible/roles/yarn/templates/yarn-site.xml
@@ -38,6 +38,14 @@
     <name>yarn.nodemanager.log.retain-seconds</name>
     <value>3600</value>
   </property>
+    <property>
+    <name>yarn.nodemanager.recovery.enabled</name>
+    <value>true</value>
+  </property>
+  <property>
+      <name>yarn.nodemanager.address</name>
+    <value>0.0.0.0:45454</value>
+  </property>
   <property>
     <name>yarn.nodemanager.resource.cpu-vcores</name>
     <value>{{yarn_vcores}}</value>


### PR DESCRIPTION
We identified that, whenever nodemanager getting restarted the process/containers become orphan process. To prevent this need to add this yarn.nodemanager.recovery.enabled flag and it requires nodemanager restart in all the yarn-slaves.