### PR TITLE
Druid Ingestion Spec Update 

### DIFF
--- a/druid/ingestion-spec/summary_index_kafka.json
+++ b/druid/ingestion-spec/summary_index_kafka.json
@@ -340,7 +340,7 @@
                     },
                     {
                         "type": "path",
-                        "name": "device_loc_district_custom",
+                        "name": "device_loc_district",
                         "expr": "$.devicedata.districtcustom"
                     },
                     {
@@ -723,7 +723,7 @@
                     },
                     {
                         "type": "string",
-                        "name": "device_loc_district_custom"
+                        "name": "device_loc_district"
                     },
                     {
                         "type": "string",

--- a/druid/ingestion-spec/summary_index_kafka.json
+++ b/druid/ingestion-spec/summary_index_kafka.json
@@ -330,6 +330,21 @@
                     },
                     {
                         "type": "path",
+                        "name": "device_state_custom_code",
+                        "expr": "$.devicedata.statecustomcode"
+                    },
+                    {
+                        "type": "path",
+                        "name": "device_state_custom_name",
+                        "expr": "$.devicedata.statecustomname"
+                    },
+                    {
+                        "type": "path",
+                        "name": "device_district_custom",
+                        "expr": "$.devicedata.districtcustom"
+                    },
+                    {
+                        "type": "path",
                         "name": "content_name",
                         "expr": "$.contentdata.name"
                     },
@@ -692,6 +707,18 @@
                     {
                         "type": "long",
                         "name": "device_first_access"
+                    },
+                    {
+                        "type": "string",
+                        "name": "device_state_custom_code"
+                    },
+                    {
+                        "type": "string",
+                        "name": "device_state_custom_name"
+                    },
+                    {
+                        "type": "string",
+                        "name": "device_district_custom"
                     },
                     {
                         "type": "string",

--- a/druid/ingestion-spec/summary_index_kafka.json
+++ b/druid/ingestion-spec/summary_index_kafka.json
@@ -19,6 +19,10 @@
                     },
                     {
                         "type": "root",
+                        "name": "mid"
+                    },
+                    {
+                        "type": "root",
                         "name": "ver"
                     },
                     {
@@ -461,6 +465,10 @@
                     {
                         "type": "string",
                         "name": "eid"
+                    },
+                    {
+                        "type": "string",
+                        "name": "mid"
                     },
                     {
                         "type": "string",

--- a/druid/ingestion-spec/summary_index_kafka.json
+++ b/druid/ingestion-spec/summary_index_kafka.json
@@ -436,6 +436,11 @@
                     },
                     {
                         "type": "path",
+                        "name": "user_roles",
+                        "expr": "$.userdata.roles[*]"
+                    },
+                    {
+                        "type": "path",
                         "name": "user_loc_state",
                         "expr": "$.userdata.state"
                     },
@@ -788,6 +793,9 @@
                     {
                         "type": "string",
                         "name": "user_type"
+                    },
+                    {
+                        "name": "user_roles"
                     },
                     {
                         "type": "string",

--- a/druid/ingestion-spec/summary_index_kafka.json
+++ b/druid/ingestion-spec/summary_index_kafka.json
@@ -330,17 +330,17 @@
                     },
                     {
                         "type": "path",
-                        "name": "device_state_custom_code",
+                        "name": "device_loc_state_custom_code",
                         "expr": "$.devicedata.statecustomcode"
                     },
                     {
                         "type": "path",
-                        "name": "device_state_custom_name",
+                        "name": "device_loc_state_custom_name",
                         "expr": "$.devicedata.statecustomname"
                     },
                     {
                         "type": "path",
-                        "name": "device_district_custom",
+                        "name": "device_loc_district_custom",
                         "expr": "$.devicedata.districtcustom"
                     },
                     {
@@ -710,15 +710,15 @@
                     },
                     {
                         "type": "string",
-                        "name": "device_state_custom_code"
+                        "name": "device_loc_state_custom_code"
                     },
                     {
                         "type": "string",
-                        "name": "device_state_custom_name"
+                        "name": "device_loc_state_custom_name"
                     },
                     {
                         "type": "string",
-                        "name": "device_district_custom"
+                        "name": "device_loc_district_custom"
                     },
                     {
                         "type": "string",

--- a/druid/ingestion-spec/telemetry_index_kafka.json
+++ b/druid/ingestion-spec/telemetry_index_kafka.json
@@ -412,17 +412,17 @@
             },
             {
               "type": "path",
-              "name": "device_state_custom_code",
+              "name": "device_loc_state_custom_code",
               "expr": "$.devicedata.statecustomcode"
             },
             {
               "type": "path",
-              "name": "device_state_custom_name",
+              "name": "device_loc_state_custom_name",
               "expr": "$.devicedata.statecustomname"
             },
             {
               "type": "path",
-              "name": "device_district_custom",
+              "name": "device_loc_district_custom",
               "expr": "$.devicedata.districtcustom"
             },
             {
@@ -890,15 +890,15 @@
             },
             {
               "type": "string",
-              "name": "device_state_custom_code"
+              "name": "device_loc_state_custom_code"
             },
             {
               "type": "string",
-              "name": "device_state_custom_name"
+              "name": "device_loc_state_custom_name"
             },
             {
               "type": "string",
-              "name": "device_district_custom"
+              "name": "device_loc_district_custom"
             },
             {
               "type": "string",

--- a/druid/ingestion-spec/telemetry_index_kafka.json
+++ b/druid/ingestion-spec/telemetry_index_kafka.json
@@ -15,6 +15,10 @@
             },
             {
               "type": "root",
+              "name": "mid"
+            },
+            {
+              "type": "root",
               "name": "syncts"
             },
             {
@@ -577,6 +581,10 @@
             {
               "type": "string",
               "name": "eid"
+            },
+            {
+              "type": "string",
+              "name": "mid"
             },
             {
               "type": "long",

--- a/druid/ingestion-spec/telemetry_index_kafka.json
+++ b/druid/ingestion-spec/telemetry_index_kafka.json
@@ -422,7 +422,7 @@
             },
             {
               "type": "path",
-              "name": "device_loc_district_custom",
+              "name": "device_loc_district",
               "expr": "$.devicedata.districtcustom"
             },
             {
@@ -903,7 +903,7 @@
             },
             {
               "type": "string",
-              "name": "device_loc_district_custom"
+              "name": "device_loc_district"
             },
             {
               "type": "string",

--- a/druid/ingestion-spec/telemetry_index_kafka.json
+++ b/druid/ingestion-spec/telemetry_index_kafka.json
@@ -266,6 +266,21 @@
             },
             {
               "type": "path",
+              "name": "edata_plugin_id",
+              "expr": "$.edata.plugin.id"
+            },
+            {
+              "type": "path",
+              "name": "edata_plugin_ver",
+              "expr": "$.edata.plugin.ver"
+            },
+            {
+              "type": "path",
+              "name": "edata_plugin_category",
+              "expr": "$.edata.plugin.category"
+            },
+            {
+              "type": "path",
               "name": "edata_state",
               "expr": "$.edata.state"
             },
@@ -781,6 +796,18 @@
             {
               "type": "string",
               "name": "edata_items_to_type"
+            },
+            {
+              "type": "string",
+              "name": "edata_plugin_id"
+            },
+            {
+              "type": "string",
+              "name": "edata_plugin_ver"
+            },
+            {
+              "type": "string",
+              "name": "edata_plugin_category"
             },
             {
               "type": "string",

--- a/druid/ingestion-spec/telemetry_index_kafka.json
+++ b/druid/ingestion-spec/telemetry_index_kafka.json
@@ -412,6 +412,21 @@
             },
             {
               "type": "path",
+              "name": "device_state_custom_code",
+              "expr": "$.devicedata.statecustomcode"
+            },
+            {
+              "type": "path",
+              "name": "device_state_custom_name",
+              "expr": "$.devicedata.statecustomname"
+            },
+            {
+              "type": "path",
+              "name": "device_district_custom",
+              "expr": "$.devicedata.districtcustom"
+            },
+            {
+              "type": "path",
               "name": "content_name",
               "expr": "$.contentdata.name"
             },
@@ -872,6 +887,18 @@
             {
               "type": "long",
               "name": "device_first_access"
+            },
+            {
+              "type": "string",
+              "name": "device_state_custom_code"
+            },
+            {
+              "type": "string",
+              "name": "device_state_custom_name"
+            },
+            {
+              "type": "string",
+              "name": "device_district_custom"
             },
             {
               "type": "string",

--- a/druid/ingestion-spec/telemetry_index_kafka.json
+++ b/druid/ingestion-spec/telemetry_index_kafka.json
@@ -517,6 +517,11 @@
             },
             {
               "type": "path",
+              "name": "user_roles",
+              "expr": "$.userdata.roles[*]"
+            },
+            {
+              "type": "path",
               "name": "user_loc_state",
               "expr": "$.userdata.state"
             },
@@ -967,6 +972,9 @@
             {
               "type": "string",
               "name": "user_type"
+            },
+            {
+              "name": "user_roles"
             },
             {
               "type": "string",


### PR DESCRIPTION
@anandp504 
Added below fields into in both `summary` and `telemetry` ingestion spec.

1. `statecustomname`
2. `districtcustom`
3. `statecustomcode`
4. `roles`
4. `mid`
5. `edata_plugin_id`
6. `edata_plugin_ver`
7. `edata_plugin_category`