### PR TITLE
Issue#000 feat: Add edata.props field from AUDIT event

### DIFF
--- a/druid/ingestion-spec/telemetry_index_kafka.json
+++ b/druid/ingestion-spec/telemetry_index_kafka.json
@@ -815,7 +815,7 @@
               "name": "edata_plugin_category"
             },
             {
-              "name": "edata_state"
+              "name": "edata_props"
             },
             {
               "type": "string",

--- a/druid/ingestion-spec/telemetry_index_kafka.json
+++ b/druid/ingestion-spec/telemetry_index_kafka.json
@@ -281,6 +281,11 @@
             },
             {
               "type": "path",
+              "name": "edata_props",
+              "expr": "$.edata.props[*]"
+            },
+            {
+              "type": "path",
               "name": "edata_state",
               "expr": "$.edata.state"
             },
@@ -808,6 +813,9 @@
             {
               "type": "string",
               "name": "edata_plugin_category"
+            },
+            {
+              "name": "edata_state"
             },
             {
               "type": "string",


### PR DESCRIPTION
edata.props field needs to be added for the AUDIT events into Druid
ingestion spec for telemetry events. edata.props will have datatype of
List<String>.