### PR TITLE
Feat #0000: updated the ansible syntax to take the cluster ips

### DIFF
--- a/ansible/roles/zookeeper-upgrade/templates/zoo.cfg.j2
+++ b/ansible/roles/zookeeper-upgrade/templates/zoo.cfg.j2
@@ -8,6 +8,5 @@ maxClientCnxns={{ maxclinetconnection_limit }}
 
 
 {% for host in zookeeper_group %}
-server.{{hostvars[host]['server_id']}}={{hostvars[host].ansible_default_ipv4.address }}:2888:3888
+server.{{hostvars[host]['server_id']}}={{ host }}:2888:3888
 {% endfor %}
-


### PR DESCRIPTION
With the old syntax, ips were not updated correctly and this addition is required to update the kafka cluster ips