### PR TITLE
Issue #000 fix: Handle redis connection resource closing gracefully

### DIFF
--- a/data-pipeline/de-normalization/src/main/java/org/ekstep/ep/samza/service/DeNormalizationService.java
+++ b/data-pipeline/de-normalization/src/main/java/org/ekstep/ep/samza/service/DeNormalizationService.java
@@ -14,7 +14,7 @@ import static java.text.MessageFormat.format;
 
 public class DeNormalizationService {
 
-    static Logger LOGGER = new Logger(DeNormalizationService.class);
+    private static Logger LOGGER = new Logger(DeNormalizationService.class);
     private final DeNormalizationConfig config;
     private final EventUpdaterFactory eventUpdaterFactory;
 

--- a/data-pipeline/de-normalization/src/main/java/org/ekstep/ep/samza/util/DataCache.java
+++ b/data-pipeline/de-normalization/src/main/java/org/ekstep/ep/samza/util/DataCache.java
@@ -32,8 +32,10 @@ public class DataCache {
         } catch (JedisException ex) {
             LOGGER.error("", "Exception when retrieving data from redis cache ", ex);
             redisConnect.resetConnection();
-            redisConnection = redisConnect.getConnection(databaseIndex);
-            cacheDataMap = getDataFromCache(key);
+            try (Jedis redisConn = redisConnect.getConnection(databaseIndex)) {
+                this.redisConnection = redisConn;
+                cacheDataMap = getDataFromCache(key);
+            }
         }
         return cacheDataMap;
     }

--- a/data-pipeline/de-normalization/src/main/java/org/ekstep/ep/samza/util/UserDataCache.java
+++ b/data-pipeline/de-normalization/src/main/java/org/ekstep/ep/samza/util/UserDataCache.java
@@ -59,8 +59,10 @@ public class UserDataCache extends DataCache {
             }
         } catch (JedisException ex) {
             redisPool.resetConnection();
-            redisConnection = redisPool.getConnection(databaseIndex);
-            userDataMap = getUserDataFromCache(userId);
+            try (Jedis redisConn = redisPool.getConnection(databaseIndex)) {
+                this.redisConnection = redisConn;
+                userDataMap = getUserDataFromCache(userId);
+            }
         }
 
         Map<String, Object> userLocationMap;

--- a/data-pipeline/ep-core/src/main/java/org/ekstep/ep/samza/util/RedisConnect.java
+++ b/data-pipeline/ep-core/src/main/java/org/ekstep/ep/samza/util/RedisConnect.java
@@ -45,6 +45,7 @@ public class RedisConnect {
     }
 
     public void resetConnection() {
+        this.jedisPool.close();
         String redis_host = config.get("redis.host", "localhost");
         Integer redis_port = config.getInt("redis.port", 6379);
         this.jedisPool = new JedisPool(buildPoolConfig(), redis_host, redis_port);

--- a/data-pipeline/events-router/src/main/java/org/ekstep/ep/samza/domain/DeDupEngine.java
+++ b/data-pipeline/events-router/src/main/java/org/ekstep/ep/samza/domain/DeDupEngine.java
@@ -22,4 +22,8 @@ public class DeDupEngine {
         redisConnection.set(checksum, "");
         redisConnection.expire(checksum, expirySeconds);
     }
+
+    public Jedis getRedisConnection() {
+        return redisConnection;
+    }
 }

--- a/data-pipeline/events-router/src/main/java/org/ekstep/ep/samza/service/EventsRouterService.java
+++ b/data-pipeline/events-router/src/main/java/org/ekstep/ep/samza/service/EventsRouterService.java
@@ -69,6 +69,7 @@ public class EventsRouterService {
 			}
 		} catch (JedisException e) {
 			LOGGER.error(null, "Exception when retrieving data from redis: ", e);
+			deDupEngine.getRedisConnection().close();
 			throw e;
 		} catch (JsonSyntaxException e) {
 			LOGGER.error(null, "INVALID EVENT: " + source.getMessage());

--- a/data-pipeline/redis-updater/src/main/java/org/ekstep/ep/samza/service/RedisUpdaterService.java
+++ b/data-pipeline/redis-updater/src/main/java/org/ekstep/ep/samza/service/RedisUpdaterService.java
@@ -72,8 +72,10 @@ public class RedisUpdaterService {
             sink.error();
             LOGGER.error("", "Exception when adding to dialcode redis cache", ex);
             redisConnect.resetConnection();
-            redisConnect.getConnection(dialCodeStoreDb);
-            addToCache(nodeUniqueId, gson.toJson(parsedData), dialCodeStoreConnection);
+            try (Jedis redisConn = redisConnect.getConnection(dialCodeStoreDb)) {
+                this.dialCodeStoreConnection = redisConn;
+                addToCache(nodeUniqueId, gson.toJson(parsedData), dialCodeStoreConnection);
+            }
         }
     }
 
@@ -116,18 +118,20 @@ public class RedisUpdaterService {
             sink.error();
             LOGGER.error("", "Exception when adding to content store redis cache", ex);
             redisConnect.resetConnection();
-            redisConnect.getConnection(contentStoreDb);
-            addToCache(nodeUniqueId, gson.toJson(parsedData), contentStoreConnection);
+            try (Jedis redisConn = redisConnect.getConnection(contentStoreDb)) {
+                this.contentStoreConnection = redisConn;
+                addToCache(nodeUniqueId, gson.toJson(parsedData), contentStoreConnection);
+            }
         }
     }
 
     private List<String> toList(String value) {
         if (value != null) {
-            List<String> val = new ArrayList<String>();
+            List<String> val = new ArrayList<>();
             val.add(value);
             return val;
         } else {
-            return new ArrayList<String>();
+            return new ArrayList<>();
         }
     }
 

--- a/data-pipeline/telemetry-location-updater/src/main/java/org/ekstep/ep/samza/service/TelemetryLocationUpdaterService.java
+++ b/data-pipeline/telemetry-location-updater/src/main/java/org/ekstep/ep/samza/service/TelemetryLocationUpdaterService.java
@@ -1,6 +1,7 @@
 package org.ekstep.ep.samza.service;
 
 import com.google.gson.JsonSyntaxException;
+
 import org.ekstep.ep.samza.core.JobMetrics;
 import org.ekstep.ep.samza.core.Logger;
 import org.ekstep.ep.samza.domain.DeviceProfile;

--- a/data-pipeline/telemetry-location-updater/src/main/java/org/ekstep/ep/samza/util/DeviceProfileCache.java
+++ b/data-pipeline/telemetry-location-updater/src/main/java/org/ekstep/ep/samza/util/DeviceProfileCache.java
@@ -43,8 +43,10 @@ public class DeviceProfileCache {
             } catch (JedisException ex) {
                 LOGGER.error(null, "Reconnecting with Redis store due to exception: ", ex);
                 redisConnect.resetConnection();
-                this.redisConnection = redisConnect.getConnection(databaseIndex);
-                deviceProfile = getDeviceProfileFromCache(did);
+                try (Jedis redisConn = redisConnect.getConnection(databaseIndex)) {
+                    this.redisConnection = redisConn;
+                    deviceProfile = getDeviceProfileFromCache(did);
+                }
             }
 
             if (null != deviceProfile && deviceProfile.isLocationResolved()) {


### PR DESCRIPTION
1. RedisPool needs to be closed when resetConnection is called.
2. Use java try-with-resources while obtaining connection from pool.