### PR TITLE
DO-1021 updated the hostname to coordinator

### DIFF
--- a/ansible/druid-ingestion.yml
+++ b/ansible/druid-ingestion.yml
@@ -1,6 +1,6 @@
 ---
 
-- hosts: druid
+- hosts: overlord
   become: yes
   roles:
      - druid-ingestion


### PR DESCRIPTION
This change is required to run the ingestion task on coordinator host group.