### PR TITLE
Issue #SB-14300 - changed codec to plain for device logs

### DIFF
--- a/ansible/roles/ep_logstash/templates/logstash.conf.indexer.device_api_metrics
+++ b/ansible/roles/ep_logstash/templates/logstash.conf.indexer.device_api_metrics
@@ -30,7 +30,7 @@ output {
       kafka {
         bootstrap_servers => "{{kafka_brokers}}"
         topic_id => "{{kafka_topic_prefix}}.events.deviceprofile"
-        codec => line {
+        codec => plain {
           format => "%{message}"
         }
       }


### PR DESCRIPTION
Changed codec to plain for device logs to avoid new line insertion in kafka messages and secor backup.