### PR TITLE
Issue #SB-14867 fix: Assessment dp report config

### DIFF
--- a/ansible/roles/data-products-deploy/templates/common.conf.j2
+++ b/ansible/roles/data-products-deploy/templates/common.conf.j2
@@ -157,6 +157,8 @@ assessment.metrics.es.alias="cbatch-assessment"
 assessment.metrics.es.index.prefix="cbatch-assessment-"
 course.upload.reports.enabled=true
 course.es.index.enabled=true
+assessment.metrics.bestscore.report=true // BestScore or Latst Updated Score
+assessment.metrics.supported.contenttype="SelfAssess"
 
 # content rating configurations
 


### PR DESCRIPTION
Configuration for the assessment report data product to generate the report only for "SelfAssess" content types and best attempt score