### PR TITLE
Issue #SC-1407 update: removed folder "admin-user-reports".

### DIFF
--- a/ansible/roles/data-products-deploy/templates/common.conf.j2
+++ b/ansible/roles/data-products-deploy/templates/common.conf.j2
@@ -150,7 +150,7 @@ es.composite.host="{{groups['composite-search-cluster'][0]}}"
 # State admin user reports
 # Uses azure only - course.metrics.cloud.provider
 admin.reports.cloud.container="reports"
-admin.metrics.cloud.objectKey="admin-user-reports/"
+admin.metrics.cloud.objectKey=""
 admin.metrics.temp.dir="/mount/data/analytics/admin-user-reports"
 
 #Assessment report config


### PR DESCRIPTION
Now admin reports goes directly into root folder inside "reports" container