### PR TITLE
WFS optimisations - submit-script implementation

### DIFF
--- a/ansible/inventory/env/group_vars/all.yml
+++ b/ansible/inventory/env/group_vars/all.yml
@@ -185,7 +185,7 @@ druid_ingestion_specs:
       ingestion_file_name: 'pipeline_metrics_index_kafka'
 
 #Druid Proxy APi service
-sunbird_druid_broker_host: "http://{{ groups['broker'][0] }}"
+sunbird_druid_broker_host: "http://{{ groups['raw-broker'][0] }}"
 sunbird_learner_service_url: "{{swarm_manager_lb_ip}}:9000"
 
 location_search_url: "{{ domain_name }}/api/data/"

--- a/ansible/roles/analytics-api-deploy/templates/conf.j2
+++ b/ansible/roles/analytics-api-deploy/templates/conf.j2
@@ -248,7 +248,7 @@ experimentService.redisEmptyValueExpirySeconds=86400
 redis.experimentIndex=9
 redis.deviceIndex=2
 
-druid.coordinator.host="http://{{groups['coordinator'][0]}}:8081/"
+druid.coordinator.host="http://{{groups['raw-coordinator'][0]}}:8081/"
 druid.healthcheck.url="druid/coordinator/v1/loadstatus"
 
 device.api.enable.debug.log=true

--- a/ansible/roles/data-products-deploy/defaults/main.yml
+++ b/ansible/roles/data-products-deploy/defaults/main.yml
@@ -152,7 +152,7 @@ analytics:
   home: /mount/data/analytics
   soft_path: /mount/data/analytics
   paths: ['/home/analytics/sbin', '/mount/data/analytics', '/mount/data/analytics/logs', '/mount/data/analytics/logs/services', '/mount/data/analytics/logs/data-products', '/mount/data/analytics/logs/api-service', '/mount/data/analytics/api', '/mount/data/analytics/tmp', '/mount/data/analytics/scripts/monitor-data', '/mount/data/analytics/models' ]
-  scripts: ['model-config', 'replay-job', 'replay-updater', 'replay-utils', 'run-job', 'monitor-dp', 'generate-metrics', 'submit-job', 'start-jobmanager']
+  scripts: ['model-config', 'replay-job', 'replay-updater', 'replay-utils', 'run-job', 'monitor-dp', 'generate-metrics', 'submit-job', 'start-jobmanager', 'submit-script']
 
 
 producer_env: "dev.sunbird"

--- a/ansible/roles/data-products-deploy/defaults/main.yml
+++ b/ansible/roles/data-products-deploy/defaults/main.yml
@@ -20,8 +20,8 @@ sink_topic: "{{ env }}.telemetry.sink"
 metrics_topic: "{{ env }}.telemetry.metrics"
 job_manager_tmp_dir: "transient-data"
 channel: dev-test
-druid_broker_host: "{{groups['broker'][0]}}"
-druid_rollup_broker_host: "{{groups['broker'][0]}}"
+druid_broker_host: "{{groups['raw-broker'][0]}}"
+druid_rollup_broker_host: "{{groups['raw-broker'][0]}}"
 hierarchySearchServiceUrl: "{{ proto }}://{{ domain_name }}/action/content"
 hierarchySearchServicEndpoint: /v3/hierarchy/
 

--- a/ansible/roles/data-products-deploy/templates/submit-script.j2
+++ b/ansible/roles/data-products-deploy/templates/submit-script.j2
@@ -58,15 +58,15 @@ if [ "$mode" = "via-partition" ]; then
                 finalConfig=${job_config/'"delta":0'/$partitionString}
                 echo $finalConfig
                 echo "Running $job by partitions."
-                classVariable='--class org.ekstep.analytics.job.JobExecutor $MODELS_HOME/batch-models-2.0.jar --model "$job" --config "$finalConfig"'
+                classVariable="--class org.ekstep.analytics.job.JobExecutor $MODELS_HOME/batch-models-2.0.jar"
             else 
                 job_config=$(config $job '__endDate__')
                 finalConfig=${job_config/'"delta":0'/$partitionString}
                 echo $finalConfig
                 echo "Running $job by partitions via Replay-Supervisor."
-                classVariable='--class org.ekstep.analytics.job.ReplaySupervisor $MODELS_HOME/batch-models-2.0.jar --model "$job" --fromDate "$start_date" --toDate "$end_date" --config "$finalConfig"'
+                classVariable="--class org.ekstep.analytics.job.ReplaySupervisor $MODELS_HOME/batch-models-2.0.jar"
             fi
-            $SPARK_HOME/bin/spark-submit --master $sparkMaster --jars $(echo ${libs_path}/lib/*.jar | tr ' ' ','),$MODELS_HOME/analytics-framework-2.0.jar,$MODELS_HOME/scruid_2.11-2.3.2.jar,$MODELS_HOME/batch-models-2.0.jar $classVariable >> "$DP_LOGS/$today-job-execution.log"
+            $SPARK_HOME/bin/spark-submit --master $sparkMaster --jars $(echo ${libs_path}/lib/*.jar | tr ' ' ','),$MODELS_HOME/analytics-framework-2.0.jar,$MODELS_HOME/scruid_2.11-2.3.2.jar,$MODELS_HOME/batch-models-2.0.jar $classVariable  --model "$job" --fromDate "$start_date" --toDate "$end_date" --config "$finalConfig" >> "$DP_LOGS/$today-job-execution.log"
         done
 elif [ "$mode" = "job-manager" ]; then
     # push job-config to kafka      
@@ -77,11 +77,11 @@ else
     if [ -z "$start_date" ]; then
         echo "Running $job without partition via run-job."
         job_config=$(config $job)
-        classVariable='--class org.ekstep.analytics.job.JobExecutor $MODELS_HOME/batch-models-2.0.jar --model "$job" --config "$job_config"'
+        classVariable="--class org.ekstep.analytics.job.JobExecutor $MODELS_HOME/batch-models-2.0.jar"
     else   
         job_config=$(config $job '__endDate__')
         echo "Running $job without partition via Replay-Supervisor." 
-        classVariable='--class org.ekstep.analytics.job.ReplaySupervisor $MODELS_HOME/batch-models-2.0.jar --model "$job" --fromDate "$start_date" --toDate "$end_date" --config "$job_config"'
+        classVariable="--class org.ekstep.analytics.job.ReplaySupervisor $MODELS_HOME/batch-models-2.0.jar"
     fi  
-    $SPARK_HOME/bin/spark-submit --master $sparkMaster --jars $(echo ${libs_path}/lib/*.jar | tr ' ' ','),$MODELS_HOME/analytics-framework-2.0.jar,$MODELS_HOME/scruid_2.11-2.3.2.jar,$MODELS_HOME/batch-models-2.0.jar $classVariable >> "$DP_LOGS/$today-job-execution.log"  
+    $SPARK_HOME/bin/spark-submit --master $sparkMaster --jars $(echo ${libs_path}/lib/*.jar | tr ' ' ','),$MODELS_HOME/analytics-framework-2.0.jar,$MODELS_HOME/scruid_2.11-2.3.2.jar,$MODELS_HOME/batch-models-2.0.jar $classVariable --model "$job" --fromDate "$start_date" --toDate "$end_date" --config "$job_config" >> "$DP_LOGS/$today-job-execution.log"  
 fi

--- a/ansible/roles/data-products-deploy/templates/submit-script.j2
+++ b/ansible/roles/data-products-deploy/templates/submit-script.j2
@@ -58,13 +58,13 @@ if [ "$mode" = "via-partition" ]; then
                 finalConfig=${job_config/'"delta":0'/$partitionString}
                 echo $finalConfig
                 echo "Running $job by partitions."
-                classVariable=\"--class org.ekstep.analytics.job.JobExecutor $MODELS_HOME/batch-models-2.0.jar --model "$job" --config "$finalConfig"\"
+                classVariable="--class org.ekstep.analytics.job.JobExecutor $MODELS_HOME/batch-models-2.0.jar --model "$job" --config "$finalConfig""
             else 
                 job_config=$(config $job '__endDate__')
                 finalConfig=${job_config/'"delta":0'/$partitionString}
                 echo $finalConfig
                 echo "Running $job by partitions via Replay-Supervisor."
-                classVariable=\"--class org.ekstep.analytics.job.ReplaySupervisor $MODELS_HOME/batch-models-2.0.jar --model "$job" --fromDate "$start_date" --toDate "$end_date" --config "$finalConfig"\"
+                classVariable="--class org.ekstep.analytics.job.ReplaySupervisor $MODELS_HOME/batch-models-2.0.jar --model "$job" --fromDate "$start_date" --toDate "$end_date" --config "$finalConfig""
             fi
             $SPARK_HOME/bin/spark-submit --master $sparkMaster --jars $(echo ${libs_path}/lib/*.jar | tr ' ' ','),$MODELS_HOME/analytics-framework-2.0.jar,$MODELS_HOME/scruid_2.11-2.3.2.jar,$MODELS_HOME/batch-models-2.0.jar $classVariable >> "$DP_LOGS/$today-job-execution.log"
         done
@@ -77,11 +77,11 @@ else
     if [ -z "$start_date" ]; then
         echo "Running $job without partition via run-job."
         job_config=$(config $job)
-        classVariable=\"--class org.ekstep.analytics.job.JobExecutor $MODELS_HOME/batch-models-2.0.jar --model "$job" --config "$job_config"\"
+        classVariable="--class org.ekstep.analytics.job.JobExecutor $MODELS_HOME/batch-models-2.0.jar --model "$job" --config "$job_config""
     else   
         job_config=$(config $job '__endDate__')
         echo "Running $job without partition via Replay-Supervisor." 
-        classVariable=\"--class org.ekstep.analytics.job.ReplaySupervisor $MODELS_HOME/batch-models-2.0.jar --model "$job" --fromDate "$start_date" --toDate "$end_date" --config "$job_config"\"
+        classVariable="--class org.ekstep.analytics.job.ReplaySupervisor $MODELS_HOME/batch-models-2.0.jar --model "$job" --fromDate "$start_date" --toDate "$end_date" --config "$job_config""
     fi  
     $SPARK_HOME/bin/spark-submit --master $sparkMaster --jars $(echo ${libs_path}/lib/*.jar | tr ' ' ','),$MODELS_HOME/analytics-framework-2.0.jar,$MODELS_HOME/scruid_2.11-2.3.2.jar,$MODELS_HOME/batch-models-2.0.jar $classVariable >> "$DP_LOGS/$today-job-execution.log"  
 fi

--- a/ansible/roles/data-products-deploy/templates/submit-script.j2
+++ b/ansible/roles/data-products-deploy/templates/submit-script.j2
@@ -18,16 +18,13 @@ unique_topic={{ env }}.telemetry.unique
 
 while :; do
     case $1 in
-        -c|--job)   shift 
+        -j|--job)   shift 
                     job="$1"            
         ;;
         -m|--mode)  shift 
-                    type="$1"            
+                    mode="$1"            
         ;;
-        -p|--partitions)    shift 
-                            partitions=$1          
-        ;;
-        -s|--parallelisation)   shift 
+        -p|--parallelisation)   shift 
                                 parallelisation=$1            
         ;;
         -sd|--startDate)   shift 
@@ -46,9 +43,9 @@ done
 
 if [ -z "$sparkMaster" ]; then sparkMaster="local[*]"; else sparkMaster="$sparkMaster"; fi
 
-if [ "$type" = "via-partition" ]; then
+if [ "$mode" = "via-partition" ]; then
     # get partitions from kafka metadata
-    if [ -z "$partitions" ]; then partitions=`$KAFKA_HOME/bin/kafka-topics.sh --zookeeper $zookeeper --describe --topic $unique_topic   | awk 'NR==1{print $2}' |  awk -F":" '{print $2}'`; else partitions=$partitions; fi
+    partitions=`$KAFKA_HOME/bin/kafka-topics.sh --zookeeper $zookeeper --describe --topic $unique_topic   | awk 'NR==1{print $2}' |  awk -F":" '{print $2}'`
     endPartitions=`expr $partitions - 1`
     if [ -z "$parallelisation" ]; then parallelisation=1; else parallelisation=$parallelisation; fi
     # add partitions to config and start jobs
@@ -61,16 +58,16 @@ if [ "$type" = "via-partition" ]; then
                 finalConfig=${job_config/'"delta":0'/$partitionString}
                 echo $finalConfig
                 echo "Running $job by partitions."
-                nohup $SPARK_HOME/bin/spark-submit --master $sparkMaster --jars $(echo ${libs_path}/lib/*.jar | tr ' ' ','),$MODELS_HOME/analytics-framework-2.0.jar,$MODELS_HOME/scruid_2.11-2.3.2.jar,$MODELS_HOME/batch-models-2.0.jar --class org.ekstep.analytics.job.JobExecutor $MODELS_HOME/batch-models-2.0.jar --model "$job" --config "$finalConfig" >> "$DP_LOGS/$today-job-execution.log" 2>&1
+                $SPARK_HOME/bin/spark-submit --master $sparkMaster --jars $(echo ${libs_path}/lib/*.jar | tr ' ' ','),$MODELS_HOME/analytics-framework-2.0.jar,$MODELS_HOME/scruid_2.11-2.3.2.jar,$MODELS_HOME/batch-models-2.0.jar --class org.ekstep.analytics.job.JobExecutor $MODELS_HOME/batch-models-2.0.jar --model "$job" --config "$finalConfig" >> "$DP_LOGS/$today-job-execution.log"
             else 
                 job_config=$(config $job '__endDate__')
                 finalConfig=${job_config/'"delta":0'/$partitionString}
                 echo $finalConfig
                 echo "Running $job by partitions via Replay-Supervisor."
-                nohup $SPARK_HOME/bin/spark-submit --master $sparkMaster --jars $MODELS_HOME/analytics-framework-2.0.jar,$MODELS_HOME/scruid_2.11-2.3.2.jar --class org.ekstep.analytics.job.ReplaySupervisor $MODELS_HOME/batch-models-2.0.jar --model "$job" --fromDate "$start_date" --toDate "$end_date" --config "$finalConfig" >> "$DP_LOGS/$end_date-$job-replay.log" 2>&1
+                $SPARK_HOME/bin/spark-submit --master $sparkMaster --jars $MODELS_HOME/analytics-framework-2.0.jar,$MODELS_HOME/scruid_2.11-2.3.2.jar --class org.ekstep.analytics.job.ReplaySupervisor $MODELS_HOME/batch-models-2.0.jar --model "$job" --fromDate "$start_date" --toDate "$end_date" --config "$finalConfig" >> "$DP_LOGS/$end_date-$job-replay.log"
             fi
         done
-elif [ "$type" = "job-manager" ]; then
+elif [ "$mode" = "job-manager" ]; then
     # push job-config to kafka      
     echo "Submitting $job to job-manager."
     echo '{ "model" :' \"$job\" ',' ' "config": ' "$job_config" '}' > /tmp/job-request.json
@@ -79,10 +76,10 @@ else
     if [ -z "$start_date" ]; then
         echo "Running $job without partition via run-job."
         job_config=$(config $job)
-        nohup $SPARK_HOME/bin/spark-submit --master $sparkMaster --jars $(echo ${libs_path}/lib/*.jar | tr ' ' ','),$MODELS_HOME/analytics-framework-2.0.jar,$MODELS_HOME/scruid_2.11-2.3.2.jar,$MODELS_HOME/batch-models-2.0.jar --class org.ekstep.analytics.job.JobExecutor $MODELS_HOME/batch-models-2.0.jar --model "$job" --config "$job_config" >> "$DP_LOGS/$today-job-execution.log" 2>&1
+        $SPARK_HOME/bin/spark-submit --master $sparkMaster --jars $(echo ${libs_path}/lib/*.jar | tr ' ' ','),$MODELS_HOME/analytics-framework-2.0.jar,$MODELS_HOME/scruid_2.11-2.3.2.jar,$MODELS_HOME/batch-models-2.0.jar --class org.ekstep.analytics.job.JobExecutor $MODELS_HOME/batch-models-2.0.jar --model "$job" --config "$job_config" >> "$DP_LOGS/$today-job-execution.log"
     else   
         job_config=$(config $job '__endDate__')
         echo "Running $job without partition via Replay-Supervisor." 
-        nohup $SPARK_HOME/bin/spark-submit --master $sparkMaster --jars $MODELS_HOME/analytics-framework-2.0.jar,$MODELS_HOME/scruid_2.11-2.3.2.jar --class org.ekstep.analytics.job.ReplaySupervisor $MODELS_HOME/batch-models-2.0.jar --model "$job" --fromDate "$start_date" --toDate "$end_date" --config "$job_config" >> "$DP_LOGS/$end_date-$job-replay.log" 2>&1
+        $SPARK_HOME/bin/spark-submit --master $sparkMaster --jars $MODELS_HOME/analytics-framework-2.0.jar,$MODELS_HOME/scruid_2.11-2.3.2.jar --class org.ekstep.analytics.job.ReplaySupervisor $MODELS_HOME/batch-models-2.0.jar --model "$job" --fromDate "$start_date" --toDate "$end_date" --config "$job_config" >> "$DP_LOGS/$end_date-$job-replay.log"
     fi    
 fi

--- a/ansible/roles/data-products-deploy/templates/submit-script.j2
+++ b/ansible/roles/data-products-deploy/templates/submit-script.j2
@@ -58,14 +58,15 @@ if [ "$mode" = "via-partition" ]; then
                 finalConfig=${job_config/'"delta":0'/$partitionString}
                 echo $finalConfig
                 echo "Running $job by partitions."
-                $SPARK_HOME/bin/spark-submit --master $sparkMaster --jars $(echo ${libs_path}/lib/*.jar | tr ' ' ','),$MODELS_HOME/analytics-framework-2.0.jar,$MODELS_HOME/scruid_2.11-2.3.2.jar,$MODELS_HOME/batch-models-2.0.jar --class org.ekstep.analytics.job.JobExecutor $MODELS_HOME/batch-models-2.0.jar --model "$job" --config "$finalConfig" >> "$DP_LOGS/$today-job-execution.log"
+                classVariable=\"--class org.ekstep.analytics.job.JobExecutor $MODELS_HOME/batch-models-2.0.jar --model "$job" --config "$finalConfig"\"
             else 
                 job_config=$(config $job '__endDate__')
                 finalConfig=${job_config/'"delta":0'/$partitionString}
                 echo $finalConfig
                 echo "Running $job by partitions via Replay-Supervisor."
-                $SPARK_HOME/bin/spark-submit --master $sparkMaster --jars $MODELS_HOME/analytics-framework-2.0.jar,$MODELS_HOME/scruid_2.11-2.3.2.jar --class org.ekstep.analytics.job.ReplaySupervisor $MODELS_HOME/batch-models-2.0.jar --model "$job" --fromDate "$start_date" --toDate "$end_date" --config "$finalConfig" >> "$DP_LOGS/$end_date-$job-replay.log"
+                classVariable=\"--class org.ekstep.analytics.job.ReplaySupervisor $MODELS_HOME/batch-models-2.0.jar --model "$job" --fromDate "$start_date" --toDate "$end_date" --config "$finalConfig"\"
             fi
+            $SPARK_HOME/bin/spark-submit --master $sparkMaster --jars $(echo ${libs_path}/lib/*.jar | tr ' ' ','),$MODELS_HOME/analytics-framework-2.0.jar,$MODELS_HOME/scruid_2.11-2.3.2.jar,$MODELS_HOME/batch-models-2.0.jar $classVariable >> "$DP_LOGS/$today-job-execution.log"
         done
 elif [ "$mode" = "job-manager" ]; then
     # push job-config to kafka      
@@ -76,10 +77,11 @@ else
     if [ -z "$start_date" ]; then
         echo "Running $job without partition via run-job."
         job_config=$(config $job)
-        $SPARK_HOME/bin/spark-submit --master $sparkMaster --jars $(echo ${libs_path}/lib/*.jar | tr ' ' ','),$MODELS_HOME/analytics-framework-2.0.jar,$MODELS_HOME/scruid_2.11-2.3.2.jar,$MODELS_HOME/batch-models-2.0.jar --class org.ekstep.analytics.job.JobExecutor $MODELS_HOME/batch-models-2.0.jar --model "$job" --config "$job_config" >> "$DP_LOGS/$today-job-execution.log"
+        classVariable=\"--class org.ekstep.analytics.job.JobExecutor $MODELS_HOME/batch-models-2.0.jar --model "$job" --config "$job_config"\"
     else   
         job_config=$(config $job '__endDate__')
         echo "Running $job without partition via Replay-Supervisor." 
-        $SPARK_HOME/bin/spark-submit --master $sparkMaster --jars $MODELS_HOME/analytics-framework-2.0.jar,$MODELS_HOME/scruid_2.11-2.3.2.jar --class org.ekstep.analytics.job.ReplaySupervisor $MODELS_HOME/batch-models-2.0.jar --model "$job" --fromDate "$start_date" --toDate "$end_date" --config "$job_config" >> "$DP_LOGS/$end_date-$job-replay.log"
-    fi    
+        classVariable=\"--class org.ekstep.analytics.job.ReplaySupervisor $MODELS_HOME/batch-models-2.0.jar --model "$job" --fromDate "$start_date" --toDate "$end_date" --config "$job_config"\"
+    fi  
+    $SPARK_HOME/bin/spark-submit --master $sparkMaster --jars $(echo ${libs_path}/lib/*.jar | tr ' ' ','),$MODELS_HOME/analytics-framework-2.0.jar,$MODELS_HOME/scruid_2.11-2.3.2.jar,$MODELS_HOME/batch-models-2.0.jar $classVariable >> "$DP_LOGS/$today-job-execution.log"  
 fi

--- a/ansible/roles/data-products-deploy/templates/submit-script.j2
+++ b/ansible/roles/data-products-deploy/templates/submit-script.j2
@@ -58,13 +58,13 @@ if [ "$mode" = "via-partition" ]; then
                 finalConfig=${job_config/'"delta":0'/$partitionString}
                 echo $finalConfig
                 echo "Running $job by partitions."
-                classVariable="--class org.ekstep.analytics.job.JobExecutor $MODELS_HOME/batch-models-2.0.jar --model "$job" --config "$finalConfig""
+                classVariable='--class org.ekstep.analytics.job.JobExecutor $MODELS_HOME/batch-models-2.0.jar --model "$job" --config "$finalConfig"'
             else 
                 job_config=$(config $job '__endDate__')
                 finalConfig=${job_config/'"delta":0'/$partitionString}
                 echo $finalConfig
                 echo "Running $job by partitions via Replay-Supervisor."
-                classVariable="--class org.ekstep.analytics.job.ReplaySupervisor $MODELS_HOME/batch-models-2.0.jar --model "$job" --fromDate "$start_date" --toDate "$end_date" --config "$finalConfig""
+                classVariable='--class org.ekstep.analytics.job.ReplaySupervisor $MODELS_HOME/batch-models-2.0.jar --model "$job" --fromDate "$start_date" --toDate "$end_date" --config "$finalConfig"'
             fi
             $SPARK_HOME/bin/spark-submit --master $sparkMaster --jars $(echo ${libs_path}/lib/*.jar | tr ' ' ','),$MODELS_HOME/analytics-framework-2.0.jar,$MODELS_HOME/scruid_2.11-2.3.2.jar,$MODELS_HOME/batch-models-2.0.jar $classVariable >> "$DP_LOGS/$today-job-execution.log"
         done
@@ -77,11 +77,11 @@ else
     if [ -z "$start_date" ]; then
         echo "Running $job without partition via run-job."
         job_config=$(config $job)
-        classVariable="--class org.ekstep.analytics.job.JobExecutor $MODELS_HOME/batch-models-2.0.jar --model "$job" --config "$job_config""
+        classVariable='--class org.ekstep.analytics.job.JobExecutor $MODELS_HOME/batch-models-2.0.jar --model "$job" --config "$job_config"'
     else   
         job_config=$(config $job '__endDate__')
         echo "Running $job without partition via Replay-Supervisor." 
-        classVariable="--class org.ekstep.analytics.job.ReplaySupervisor $MODELS_HOME/batch-models-2.0.jar --model "$job" --fromDate "$start_date" --toDate "$end_date" --config "$job_config""
+        classVariable='--class org.ekstep.analytics.job.ReplaySupervisor $MODELS_HOME/batch-models-2.0.jar --model "$job" --fromDate "$start_date" --toDate "$end_date" --config "$job_config"'
     fi  
     $SPARK_HOME/bin/spark-submit --master $sparkMaster --jars $(echo ${libs_path}/lib/*.jar | tr ' ' ','),$MODELS_HOME/analytics-framework-2.0.jar,$MODELS_HOME/scruid_2.11-2.3.2.jar,$MODELS_HOME/batch-models-2.0.jar $classVariable >> "$DP_LOGS/$today-job-execution.log"  
 fi

--- a/ansible/roles/data-products-deploy/templates/submit-script.j2
+++ b/ansible/roles/data-products-deploy/templates/submit-script.j2
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+export SPARK_HOME={{ analytics.home }}/spark-{{ spark_version }}-bin-hadoop2.7
+export MODELS_HOME={{ analytics.home }}/models-{{ model_version }}
+export DP_LOGS={{ analytics.home }}/logs/data-products
+export KAFKA_HOME={{ analytics.home }}/kafka_2.11-0.10.1.0
+
+## Job to run daily
+cd /mount/data/analytics/scripts
+source model-config.sh
+today=$(date "+%Y-%m-%d")
+
+## job broker-list and kafka-topic
+job_brokerList={{ brokerlist }}
+job_topic={{ analytics_job_queue_topic }}
+
+type=$2
+partitions=$3
+parallelisation=$4
+start_date=$5
+end_date=$6 
+if [ -z "$7" ]; then sparkMaster="local[*]"; else sparkMaster="$7"; fi
+
+if [ "$type" = "via-partition" ]; then
+    endPartitions=`expr $partitions - 1`
+    # add partitions to config and start jobs
+    for i in $(seq 0 $parallelisation $endPartitions)
+        do 
+            # add partitions to config
+            partitionString="\"delta\":0,\"partitions\":[$(seq -s , $i `expr $i + $parallelisation - 1`)]"
+            if [ -z "$start_date" ]; then
+                job_config=$(config $1)
+                finalConfig=${job_config/'"delta":0'/$partitionString}
+                echo $finalConfig
+                echo "Running $1 by partitions."
+                nohup $SPARK_HOME/bin/spark-submit --master $sparkMaster --jars $(echo ${libs_path}/lib/*.jar | tr ' ' ','),$MODELS_HOME/analytics-framework-2.0.jar,$MODELS_HOME/scruid_2.11-2.3.2.jar,$MODELS_HOME/batch-models-2.0.jar --class org.ekstep.analytics.job.JobExecutor $MODELS_HOME/batch-models-2.0.jar --model "$1" --config "$finalConfig" >> "$DP_LOGS/$today-job-execution.log" 2>&1
+            else 
+                job_config=$(config $1 '__endDate__')
+                finalConfig=${job_config/'"delta":0'/$partitionString}
+                echo $finalConfig
+                echo "Running $1 by partitions via Replay-Supervisor."
+                nohup $SPARK_HOME/bin/spark-submit --master $sparkMaster --jars $MODELS_HOME/analytics-framework-2.0.jar,$MODELS_HOME/scruid_2.11-2.3.2.jar --class org.ekstep.analytics.job.ReplaySupervisor $MODELS_HOME/batch-models-2.0.jar --model "$1" --fromDate "$start_date" --toDate "$end_date" --config "$finalConfig" >> "$DP_LOGS/$end_date-$1-replay.log" 2>&1
+            fi
+        done
+elif [ "$type" = "job-manager" ]; then
+    # push job-config to kafka      
+    echo "Submitting $1 to job-manager."
+    echo '{ "model" :' \"$1\" ',' ' "config": ' "$job_config" '}' > /tmp/job-request.json
+    cat /tmp/job-request.json | $KAFKA_HOME/bin/kafka-console-producer.sh --broker-list $job_brokerList --topic $job_topic >> "$DP_LOGS/$today-job-execution.log" 2>&1
+else
+    if [ -z "$start_date" ]; then
+        echo "Running $1 without partition via run-job."
+        job_config=$(config $1)
+        nohup $SPARK_HOME/bin/spark-submit --master $sparkMaster --jars $(echo ${libs_path}/lib/*.jar | tr ' ' ','),$MODELS_HOME/analytics-framework-2.0.jar,$MODELS_HOME/scruid_2.11-2.3.2.jar,$MODELS_HOME/batch-models-2.0.jar --class org.ekstep.analytics.job.JobExecutor $MODELS_HOME/batch-models-2.0.jar --model "$1" --config "$job_config" >> "$DP_LOGS/$today-job-execution.log" 2>&1
+    else   
+        job_config=$(config $1 '__endDate__')
+        echo "Running $1 without partition via Replay-Supervisor." 
+        nohup $SPARK_HOME/bin/spark-submit --master $sparkMaster --jars $MODELS_HOME/analytics-framework-2.0.jar,$MODELS_HOME/scruid_2.11-2.3.2.jar --class org.ekstep.analytics.job.ReplaySupervisor $MODELS_HOME/batch-models-2.0.jar --model "$1" --fromDate "$start_date" --toDate "$end_date" --config "$job_config" >> "$DP_LOGS/$end_date-$1-replay.log" 2>&1
+    fi    
+fi

--- a/ansible/roles/data-products-deploy/templates/submit-script.j2
+++ b/ansible/roles/data-products-deploy/templates/submit-script.j2
@@ -16,48 +16,73 @@ brokerList={{ brokerlist }}
 job_topic={{ analytics_job_queue_topic }}
 unique_topic={{ env }}.telemetry.unique
 
-type=$2
-start_date=$5
-end_date=$6 
-if [ -z "$7" ]; then sparkMaster="local[*]"; else sparkMaster="$7"; fi
+while :; do
+    case $1 in
+        -c|--job)   shift 
+                    job="$1"            
+        ;;
+        -m|--mode)  shift 
+                    type="$1"            
+        ;;
+        -p|--partitions)    shift 
+                            partitions=$1          
+        ;;
+        -s|--parallelisation)   shift 
+                                parallelisation=$1            
+        ;;
+        -sd|--startDate)   shift 
+                            start_date=$1            
+        ;;
+        -ed|--endDate)     shift 
+                            end_date=$1            
+        ;;
+        -h|--sparkMaster)   shift 
+                            sparkMaster=$1            
+        ;;
+        *) break
+    esac
+    shift
+done
+
+if [ -z "$sparkMaster" ]; then sparkMaster="local[*]"; else sparkMaster="$sparkMaster"; fi
 
 if [ "$type" = "via-partition" ]; then
     # get partitions from kafka metadata
-    if [ -z "$3" ]; then partitions=`$KAFKA_HOME/bin/kafka-topics.sh --zookeeper $zookeeper --describe --topic $unique_topic   | awk 'NR==1{print $2}' |  awk -F":" '{print $2}'`; else partitions=$3; fi
+    if [ -z "$partitions" ]; then partitions=`$KAFKA_HOME/bin/kafka-topics.sh --zookeeper $zookeeper --describe --topic $unique_topic   | awk 'NR==1{print $2}' |  awk -F":" '{print $2}'`; else partitions=$partitions; fi
     endPartitions=`expr $partitions - 1`
-    if [ -z "$4" ]; then parallelisation=1; else parallelisation=$4; fi
+    if [ -z "$parallelisation" ]; then parallelisation=1; else parallelisation=$parallelisation; fi
     # add partitions to config and start jobs
     for i in $(seq 0 $parallelisation $endPartitions)
         do 
             # add partitions to config
             partitionString="\"delta\":0,\"partitions\":[$(seq -s , $i `expr $i + $parallelisation - 1`)]"
             if [ -z "$start_date" ]; then
-                job_config=$(config $1)
+                job_config=$(config $job)
                 finalConfig=${job_config/'"delta":0'/$partitionString}
                 echo $finalConfig
-                echo "Running $1 by partitions."
-                nohup $SPARK_HOME/bin/spark-submit --master $sparkMaster --jars $(echo ${libs_path}/lib/*.jar | tr ' ' ','),$MODELS_HOME/analytics-framework-2.0.jar,$MODELS_HOME/scruid_2.11-2.3.2.jar,$MODELS_HOME/batch-models-2.0.jar --class org.ekstep.analytics.job.JobExecutor $MODELS_HOME/batch-models-2.0.jar --model "$1" --config "$finalConfig" >> "$DP_LOGS/$today-job-execution.log" 2>&1
+                echo "Running $job by partitions."
+                nohup $SPARK_HOME/bin/spark-submit --master $sparkMaster --jars $(echo ${libs_path}/lib/*.jar | tr ' ' ','),$MODELS_HOME/analytics-framework-2.0.jar,$MODELS_HOME/scruid_2.11-2.3.2.jar,$MODELS_HOME/batch-models-2.0.jar --class org.ekstep.analytics.job.JobExecutor $MODELS_HOME/batch-models-2.0.jar --model "$job" --config "$finalConfig" >> "$DP_LOGS/$today-job-execution.log" 2>&1
             else 
-                job_config=$(config $1 '__endDate__')
+                job_config=$(config $job '__endDate__')
                 finalConfig=${job_config/'"delta":0'/$partitionString}
                 echo $finalConfig
-                echo "Running $1 by partitions via Replay-Supervisor."
-                nohup $SPARK_HOME/bin/spark-submit --master $sparkMaster --jars $MODELS_HOME/analytics-framework-2.0.jar,$MODELS_HOME/scruid_2.11-2.3.2.jar --class org.ekstep.analytics.job.ReplaySupervisor $MODELS_HOME/batch-models-2.0.jar --model "$1" --fromDate "$start_date" --toDate "$end_date" --config "$finalConfig" >> "$DP_LOGS/$end_date-$1-replay.log" 2>&1
+                echo "Running $job by partitions via Replay-Supervisor."
+                nohup $SPARK_HOME/bin/spark-submit --master $sparkMaster --jars $MODELS_HOME/analytics-framework-2.0.jar,$MODELS_HOME/scruid_2.11-2.3.2.jar --class org.ekstep.analytics.job.ReplaySupervisor $MODELS_HOME/batch-models-2.0.jar --model "$job" --fromDate "$start_date" --toDate "$end_date" --config "$finalConfig" >> "$DP_LOGS/$end_date-$job-replay.log" 2>&1
             fi
         done
 elif [ "$type" = "job-manager" ]; then
     # push job-config to kafka      
-    echo "Submitting $1 to job-manager."
-    echo '{ "model" :' \"$1\" ',' ' "config": ' "$job_config" '}' > /tmp/job-request.json
+    echo "Submitting $job to job-manager."
+    echo '{ "model" :' \"$job\" ',' ' "config": ' "$job_config" '}' > /tmp/job-request.json
     cat /tmp/job-request.json | $KAFKA_HOME/bin/kafka-console-producer.sh --broker-list $brokerList --topic $job_topic >> "$DP_LOGS/$today-job-execution.log" 2>&1
 else
     if [ -z "$start_date" ]; then
-        echo "Running $1 without partition via run-job."
-        job_config=$(config $1)
-        nohup $SPARK_HOME/bin/spark-submit --master $sparkMaster --jars $(echo ${libs_path}/lib/*.jar | tr ' ' ','),$MODELS_HOME/analytics-framework-2.0.jar,$MODELS_HOME/scruid_2.11-2.3.2.jar,$MODELS_HOME/batch-models-2.0.jar --class org.ekstep.analytics.job.JobExecutor $MODELS_HOME/batch-models-2.0.jar --model "$1" --config "$job_config" >> "$DP_LOGS/$today-job-execution.log" 2>&1
+        echo "Running $job without partition via run-job."
+        job_config=$(config $job)
+        nohup $SPARK_HOME/bin/spark-submit --master $sparkMaster --jars $(echo ${libs_path}/lib/*.jar | tr ' ' ','),$MODELS_HOME/analytics-framework-2.0.jar,$MODELS_HOME/scruid_2.11-2.3.2.jar,$MODELS_HOME/batch-models-2.0.jar --class org.ekstep.analytics.job.JobExecutor $MODELS_HOME/batch-models-2.0.jar --model "$job" --config "$job_config" >> "$DP_LOGS/$today-job-execution.log" 2>&1
     else   
-        job_config=$(config $1 '__endDate__')
-        echo "Running $1 without partition via Replay-Supervisor." 
-        nohup $SPARK_HOME/bin/spark-submit --master $sparkMaster --jars $MODELS_HOME/analytics-framework-2.0.jar,$MODELS_HOME/scruid_2.11-2.3.2.jar --class org.ekstep.analytics.job.ReplaySupervisor $MODELS_HOME/batch-models-2.0.jar --model "$1" --fromDate "$start_date" --toDate "$end_date" --config "$job_config" >> "$DP_LOGS/$end_date-$1-replay.log" 2>&1
+        job_config=$(config $job '__endDate__')
+        echo "Running $job without partition via Replay-Supervisor." 
+        nohup $SPARK_HOME/bin/spark-submit --master $sparkMaster --jars $MODELS_HOME/analytics-framework-2.0.jar,$MODELS_HOME/scruid_2.11-2.3.2.jar --class org.ekstep.analytics.job.ReplaySupervisor $MODELS_HOME/batch-models-2.0.jar --model "$job" --fromDate "$start_date" --toDate "$end_date" --config "$job_config" >> "$DP_LOGS/$end_date-$job-replay.log" 2>&1
     fi    
 fi

--- a/ansible/roles/data-products-deploy/templates/submit-script.j2
+++ b/ansible/roles/data-products-deploy/templates/submit-script.j2
@@ -11,18 +11,21 @@ source model-config.sh
 today=$(date "+%Y-%m-%d")
 
 ## job broker-list and kafka-topic
-job_brokerList={{ brokerlist }}
+zookeeper={{ brokerlist }}
+brokerList={{ brokerlist }}
 job_topic={{ analytics_job_queue_topic }}
+unique_topic={{ env }}.telemetry.unique
 
 type=$2
-partitions=$3
-parallelisation=$4
 start_date=$5
 end_date=$6 
 if [ -z "$7" ]; then sparkMaster="local[*]"; else sparkMaster="$7"; fi
 
 if [ "$type" = "via-partition" ]; then
+    # get partitions from kafka metadata
+    if [ -z "$3" ]; then partitions=`$KAFKA_HOME/bin/kafka-topics.sh --zookeeper $zookeeper --describe --topic $unique_topic   | awk 'NR==1{print $2}' |  awk -F":" '{print $2}'`; else partitions=$3; fi
     endPartitions=`expr $partitions - 1`
+    if [ -z "$4" ]; then parallelisation=1; else parallelisation=$4; fi
     # add partitions to config and start jobs
     for i in $(seq 0 $parallelisation $endPartitions)
         do 
@@ -46,7 +49,7 @@ elif [ "$type" = "job-manager" ]; then
     # push job-config to kafka      
     echo "Submitting $1 to job-manager."
     echo '{ "model" :' \"$1\" ',' ' "config": ' "$job_config" '}' > /tmp/job-request.json
-    cat /tmp/job-request.json | $KAFKA_HOME/bin/kafka-console-producer.sh --broker-list $job_brokerList --topic $job_topic >> "$DP_LOGS/$today-job-execution.log" 2>&1
+    cat /tmp/job-request.json | $KAFKA_HOME/bin/kafka-console-producer.sh --broker-list $brokerList --topic $job_topic >> "$DP_LOGS/$today-job-execution.log" 2>&1
 else
     if [ -z "$start_date" ]; then
         echo "Running $1 without partition via run-job."

--- a/ansible/roles/data-products-deploy/templates/submit-script.j2
+++ b/ansible/roles/data-products-deploy/templates/submit-script.j2
@@ -11,7 +11,7 @@ source model-config.sh
 today=$(date "+%Y-%m-%d")
 
 ## job broker-list and kafka-topic
-zookeeper={{ brokerlist }}
+zookeeper={{ zookeeper }}
 brokerList={{ brokerlist }}
 job_topic={{ analytics_job_queue_topic }}
 unique_topic={{ env }}.telemetry.unique


### PR DESCRIPTION
Script parameters:
**--job** - Job code. Ex: wfs
**--mode** - mode of execution. [via-partition, job-manager, run-job]
**--partitions** - partitions. Considered only if mode = via-partition.Default value is taken from unique kafka topic
**--parallelisatio**n - parallelisation. Considered only if mode = via-partition. Default value is 1
**--startDate** - start_date. Replay start date. Execution of jobs for older dates or multiple days.
**--endDate** - end_date. Replay end date. Execution of jobs for older dates or multiple days.
**--sparkMaster** - spark master URL. Used for submitting job to cluster.

Example:
- Running WFS via partition with default partitions(takes from kafka topic metadata) with parallelisation as 2
**./submit-script.sh --job wfs --mode via-partition --parallelisation 2**
- Running WFS for some old date with run mode
**./submit-script.sh --job wfs --startDate 2020-06-16 --endDate 2020-06-16**