### PR TITLE
Issue #SC-1808: Storing Orgname and userchannel in cache

### DIFF
--- a/data-pipeline-flink/user-cache-updater-2.0/src/main/resources/user-cache-updater-v2.conf
+++ b/data-pipeline-flink/user-cache-updater-2.0/src/main/resources/user-cache-updater-v2.conf
@@ -12,7 +12,7 @@ task {
 # redis-metadata
 redis-meta {
   database {
-    userstore.id = 4
+    userstore.id = 12
     key.expiry.seconds = 3600
   }
 }

--- a/data-pipeline-flink/user-cache-updater-2.0/src/main/scala/org/sunbird/dp/usercache/task/UserCacheUpdaterConfigV2.scala
+++ b/data-pipeline-flink/user-cache-updater-2.0/src/main/scala/org/sunbird/dp/usercache/task/UserCacheUpdaterConfigV2.scala
@@ -58,6 +58,7 @@ class UserCacheUpdaterConfigV2(override val config: Config) extends BaseJobConfi
   val schoolUdiseCodeKey = "schooludisecode"
   val schoolNameKey = "schoolname"
   val orgcodeKey = "orgcode"
+  val userChannelKey="userchannel"
 
   val declareExternalId = "declared-ext-id"
   val declaredSchoolName = "declared-school-name"

--- a/data-pipeline-flink/user-cache-updater-2.0/src/test/resources/data.cql
+++ b/data-pipeline-flink/user-cache-updater-2.0/src/test/resources/data.cql
@@ -263,6 +263,7 @@ CREATE TABLE sunbird.organisation (
 
 INSERT INTO sunbird.organisation (id,channel, isrootorg, locationids, orgcode, orgname) VALUES ('0123653943740170242','ROOT_ORG', False, ['location-2', 'location-3', 'location-4'], 'Org-1', 'QA ORG');
 INSERT INTO sunbird.organisation (id,channel, isrootorg, locationids, orgcode, orgname) VALUES ('0125648776347320320','ROOT_ORG', False, ['location-2', 'location-3', 'location-4'], 'Org-2', 'Sunbird ORG');
+INSERT INTO sunbird.organisation (id,channel, isrootorg, locationids, orgcode, orgname) VALUES ('01285019302823526477','ROOT_ORG', True, ['location-2', 'location-3', 'location-4'], 'Org-2', 'Custodian ORG');
 
 CREATE TABLE sunbird.usr_external_identity (
     userid text,

--- a/data-pipeline-flink/user-cache-updater-2.0/src/test/scala/org/sunbird/dp/spec/UserCacheUpdatetStreamTaskSpecV2.scala
+++ b/data-pipeline-flink/user-cache-updater-2.0/src/test/scala/org/sunbird/dp/spec/UserCacheUpdatetStreamTaskSpecV2.scala
@@ -69,7 +69,6 @@ class UserCacheUpdatetStreamTaskSpecV2 extends BaseTestSpec {
 
   def setupRedisTestData(jedis: Jedis) {
 
-
     // Insert user test data
     jedis.hmset("user-3", EventFixture.userCacheDataMap3)
     jedis.hmset("user-4", EventFixture.userCacheDataMap4)
@@ -91,8 +90,8 @@ class UserCacheUpdatetStreamTaskSpecV2 extends BaseTestSpec {
       */
     BaseMetricsReporter.gaugeMetrics(s"${userCacheConfig.jobName}.${userCacheConfig.userCacheHit}").getValue() should be(7)
     BaseMetricsReporter.gaugeMetrics(s"${userCacheConfig.jobName}.${userCacheConfig.totalEventsCount}").getValue() should be(10)
-    BaseMetricsReporter.gaugeMetrics(s"${userCacheConfig.jobName}.${userCacheConfig.dbReadSuccessCount}").getValue() should be(8)
-    BaseMetricsReporter.gaugeMetrics(s"${userCacheConfig.jobName}.${userCacheConfig.dbReadMissCount}").getValue() should be(4)
+    BaseMetricsReporter.gaugeMetrics(s"${userCacheConfig.jobName}.${userCacheConfig.dbReadSuccessCount}").getValue() should be(10)
+    BaseMetricsReporter.gaugeMetrics(s"${userCacheConfig.jobName}.${userCacheConfig.dbReadMissCount}").getValue() should be(6)
     BaseMetricsReporter.gaugeMetrics(s"${userCacheConfig.jobName}.${userCacheConfig.skipCount}").getValue() should be(4)
     BaseMetricsReporter.gaugeMetrics(s"${userCacheConfig.jobName}.${userCacheConfig.successCount}").getValue() should be(7)
 
@@ -128,6 +127,7 @@ class UserCacheUpdatetStreamTaskSpecV2 extends BaseTestSpec {
     userInfo.get("iscustodianuser") should  be ("true")
     userInfo.get("externalid") should be("93nsoa01")
     userInfo.get("schoolname") should be("SBA School")
+    assert(userInfo.get("orgname").contains("Custodian ORG"))
 
     // When action is Updated and location ids are present
     val locationInfo = jedis.hgetAll("user-4")


### PR DESCRIPTION
The PR consists of the following changes:
1. Stores rootorg user's orgname
2. Stores userchannel information 
3. Redis index pointing to new index