### PR TITLE
Collection Summary V2 - Updating the Druid Ingestion Task URL

### DIFF
--- a/ansible/roles/data-products-deploy/defaults/main.yml
+++ b/ansible/roles/data-products-deploy/defaults/main.yml
@@ -234,3 +234,7 @@ analytics_ed_dataporducts_jar_artifact: "data-products-{{ analytics_ed_datapordu
 
 druid_report_postgres_db_name: druid
 druid_report_postgres_db_username: druid
+
+#Override this variable in production and point to druid rollup ingestion cluster 
+# Example: "http://$rollup_cluster_ip:8090"
+druid_rollup_cluster_ingestion_task_url: "http://{{groups['raw-overlord'][0]}}:8081" 

--- a/ansible/roles/data-products-deploy/templates/model-config.j2
+++ b/ansible/roles/data-products-deploy/templates/model-config.j2
@@ -29,7 +29,7 @@ config() {
 	producerEnv="{{ producer_env }}"
 	baseScriptPath="{{ spark_output_temp_dir }}"
 	reportPostContainer="{{ reports_container }}"
-	druidIngestionURL="http://{{groups['raw-overlord'][0]}}:8081/druid/indexer/v1/task"
+	druidIngestionURL="{{ druid_rollup_cluster_ingestion_task_url }}/druid/indexer/v1/task"
     assessTopic={{ assess_topic }}
 
 


### PR DESCRIPTION
Creating a variable for druid ingestion URL since to override `druid_rollup_cluster_ingestion_task_url` in the production env. 