### PR TITLE
fix: SB-24008 Fix blob storage details for content model druid indexer

### DIFF
--- a/ansible/roles/content-snapshot-indexer/defaults/main.yml
+++ b/ansible/roles/content-snapshot-indexer/defaults/main.yml
@@ -46,8 +46,8 @@ cloud_storage:
   container: "telemetry-data-store" # Container is different in all env so override this.
   object_key: "druid-content-snapshot/snapshot.txt"
   provider: "azure"
-  account_name: "{{sunbird_private_storage_account_name}}"
-  account_key: "{{sunbird_private_storage_account_key}}"
+  account_name: "{{sunbird_public_storage_account_name}}"
+  account_key: "{{sunbird_public_storage_account_key}}"
 
 cassandra:
   host: "{{groups['lp-cassandra'][0]}}" ## LMS-Cassandra IP Address.


### PR DESCRIPTION
This fix is intended to resolve the issue with the blob storage account details to which the snapshot file is being uploaded to cloud storage. Currently, the snapshot file is being uploaded to a private blob storage account which causes the indexer to fail when downloading the snapshot file.

### Type of change

Please choose appropriate options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] This change involves only a configuration change to upload the snapshot file and hence no tests need to be run

**Test Configuration**:
* Software versions: NA
* Hardware versions: NA

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules