### PR TITLE
SC-2218: Update scores in user activity agg

### DIFF
--- a/data-pipeline-flink/assessment-aggregator/src/main/resources/assessment-aggregator.conf
+++ b/data-pipeline-flink/assessment-aggregator/src/main/resources/assessment-aggregator.conf
@@ -13,6 +13,9 @@ task {
   assessaggregator {
     parallelism = 1
   }
+  scoreaggregator {
+    parallelism = 1
+  }
 }
 
 lms-cassandra {
@@ -20,6 +23,7 @@ lms-cassandra {
   table = "assessment_aggregator"
   questionudttype= "question"
   enrolmentstable = "user_enrolments"
+  activitytable = "user_activity_agg"
 }
 redis {
   database {

--- a/data-pipeline-flink/assessment-aggregator/src/main/scala/org/sunbird/dp/assessment/functions/AssessmentAggregatorFunction.scala
+++ b/data-pipeline-flink/assessment-aggregator/src/main/scala/org/sunbird/dp/assessment/functions/AssessmentAggregatorFunction.scala
@@ -103,6 +103,7 @@ class AssessmentAggregatorFunction(config: AssessmentAggregatorConfig,
           saveAssessment(event, Aggregate(totalScore, totalMaxScore, grandTotal, result.toList), new DateTime().getMillis)
           metrics.incCounter(config.dbUpdateCount)
           metrics.incCounter(config.batchSuccessCount)
+          context.output(config.scoreAggregateTag, event)
           createIssueCertEvent(event, context, metrics)
         }
         else {
@@ -112,6 +113,7 @@ class AssessmentAggregatorFunction(config: AssessmentAggregatorConfig,
               assessment.getTimestamp("created_on").getTime)
             metrics.incCounter(config.dbUpdateCount)
             metrics.incCounter(config.batchSuccessCount)
+            context.output(config.scoreAggregateTag, event)
             createIssueCertEvent(event, context, metrics)
           }
           else {

--- a/data-pipeline-flink/assessment-aggregator/src/main/scala/org/sunbird/dp/assessment/functions/UserScoreAggregateFunction.scala
+++ b/data-pipeline-flink/assessment-aggregator/src/main/scala/org/sunbird/dp/assessment/functions/UserScoreAggregateFunction.scala
@@ -1,0 +1,83 @@
+package org.sunbird.dp.assessment.functions
+
+import java.lang.reflect.Type
+import java.util
+
+import com.datastax.driver.core.Row
+import com.datastax.driver.core.querybuilder.QueryBuilder
+import com.google.gson.reflect.TypeToken
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.streaming.api.functions.ProcessFunction
+import org.slf4j.LoggerFactory
+import org.sunbird.dp.assessment.domain.Event
+import org.apache.flink.configuration.Configuration
+import org.sunbird.dp.assessment.task.AssessmentAggregatorConfig
+import org.sunbird.dp.core.job.{BaseProcessFunction, Metrics}
+import org.sunbird.dp.core.util.CassandraUtil
+
+import scala.collection.JavaConverters._
+
+class UserScoreAggregateFunction(config: AssessmentAggregatorConfig,
+                                 @transient var cassandraUtil: CassandraUtil = null
+                                )(implicit val mapTypeInfo: TypeInformation[Event])
+  extends BaseProcessFunction[Event, Event](config) {
+
+    val mapType: Type = new TypeToken[util.Map[String, AnyRef]]() {}.getType
+    private[this] val logger = LoggerFactory.getLogger(classOf[UserScoreAggregateFunction])
+
+    override def metricsList() = List(config.dbScoreAggUpdateCount, config.dbScoreAggReadCount,
+        config.failedEventCount, config.batchSuccessCount,
+        config.skippedEventCount)
+
+    override def open(parameters: Configuration): Unit = {
+        super.open(parameters)
+        cassandraUtil = new CassandraUtil(config.dbHost, config.dbPort)
+    }
+
+    override def close(): Unit = {
+        super.close()
+    }
+
+    def getBestScore(event: Event) = {
+        val query = QueryBuilder.select().column("content_id").max("total_score").as("score").from(config.dbKeyspace, config.dbTable)
+          .where(QueryBuilder.eq("course_id", event.courseId)).and(QueryBuilder.eq("batch_id", event.batchId))
+          .and(QueryBuilder.eq("user_id", event.userId)).groupBy("user_id", "course_id", "batch_id", "content_id")
+        val rows: java.util.List[Row] = cassandraUtil.find(query.toString);
+        if (null != rows && !rows.isEmpty) {
+            rows.asScala.toList.map(row => {
+                "score:" + row.getString("content_id") -> rows.asScala.toList.head.getDouble("score").toInt
+            }).toMap
+        } else Map[String, Int]()
+    }
+
+    def updateUserActivity(event: Event, score: Map[String, Int]): Unit = {
+        val scoreLastUpdatedTime: Map[String, Long] = score.map(m => m._1 -> System.currentTimeMillis())
+        val updateQuery = QueryBuilder.update(config.dbKeyspace, config.activityTable)
+          .`with`(QueryBuilder.putAll(config.agg, score.asJava))
+          .and(QueryBuilder.putAll(config.aggLastUpdated, scoreLastUpdatedTime.asJava))
+          .where(QueryBuilder.eq(config.activityId, event.courseId))
+          .and(QueryBuilder.eq(config.activityType, "Course"))
+          .and(QueryBuilder.eq(config.contextId, "cb:" + event.batchId))
+          .and(QueryBuilder.eq(config.activityUser, event.userId))
+        cassandraUtil.upsert(updateQuery.toString)
+        logger.info("Successfully updated scores in user activity  - batchid: "
+          + event.batchId + " ,userid: " + event.userId + " ,couserid: "
+          + event.courseId)
+    }
+
+    override def processElement(event: Event,
+                                context: ProcessFunction[Event, Event]#Context,
+                                metrics: Metrics): Unit = {
+        val score: Map[String, Int] = getBestScore(event)
+        metrics.incCounter(config.dbScoreAggReadCount)
+        if (!score.isEmpty) {
+            updateUserActivity(event, score)
+            metrics.incCounter(config.dbScoreAggUpdateCount)
+        } else {
+            logger.info("No scores to update for batchid: "
+              + event.batchId + " ,userid: " + event.userId + " ,couserid: "
+              + event.courseId)
+        }
+    }
+
+}

--- a/data-pipeline-flink/assessment-aggregator/src/main/scala/org/sunbird/dp/assessment/functions/UserScoreAggregateFunction.scala
+++ b/data-pipeline-flink/assessment-aggregator/src/main/scala/org/sunbird/dp/assessment/functions/UserScoreAggregateFunction.scala
@@ -45,7 +45,7 @@ class UserScoreAggregateFunction(config: AssessmentAggregatorConfig,
         val rows: java.util.List[Row] = cassandraUtil.find(query.toString);
         if (null != rows && !rows.isEmpty) {
             rows.asScala.toList.map(row => {
-                "score:" + row.getString("content_id") -> rows.asScala.toList.head.getDouble("score").toInt
+                "score:" + row.getString("content_id") -> row.getDouble("score").toInt
             }).toMap
         } else Map[String, Int]()
     }

--- a/data-pipeline-flink/assessment-aggregator/src/main/scala/org/sunbird/dp/assessment/task/AssessmentAggregatorConfig.scala
+++ b/data-pipeline-flink/assessment-aggregator/src/main/scala/org/sunbird/dp/assessment/task/AssessmentAggregatorConfig.scala
@@ -18,6 +18,7 @@ class AssessmentAggregatorConfig(override val config: Config) extends BaseJobCon
   // Parallelism configs
   val assessAggregatorParallelism: Int = config.getInt("task.assessaggregator.parallelism")
   val downstreamOperatorsParallelism: Int = config.getInt("task.downstream.parallelism")
+  val scoreAggregatorParallelism: Int = config.getInt("task.scoreaggregator.parallelism")
   override val kafkaConsumerParallelism: Int = config.getInt("task.consumer.parallelism")
 
   val kafkaInputTopic: String = config.getString("kafka.input.topic")
@@ -33,6 +34,8 @@ class AssessmentAggregatorConfig(override val config: Config) extends BaseJobCon
   val cacheHitCount = "cache-hit-count"
   val cacheHitMissCount = "cache-hit-miss-count"
   val certIssueEventsCount = "cert-issue-events-count"
+  val dbScoreAggUpdateCount = "db-score-update-count"
+  val dbScoreAggReadCount = "db-score-read-count"
 
 
   //Cassandra
@@ -43,6 +46,7 @@ class AssessmentAggregatorConfig(override val config: Config) extends BaseJobCon
   val dbPort: Int = config.getInt("lms-cassandra.port")
   val dbudtType: String = config.getString("lms-cassandra.questionudttype")
   val enrolmentTable: String = config.getString("lms-cassandra.enrolmentstable")
+  val activityTable: String = config.getString("lms-cassandra.activitytable")
 
   val FAILED_EVENTS_OUTPUT_TAG = "failed-events"
 
@@ -59,8 +63,17 @@ class AssessmentAggregatorConfig(override val config: Config) extends BaseJobCon
   // Producers
   val assessFailedEventsSink = "assess-failed-events-sink"
   val certIssueEventSink = "certificate-issue-event-sink"
+  val userScoreAggregateFn = "user-score-aggregator"
 
   // Cache
   val relationCacheNode = config.getInt("redis.database.relationCache.id")
-
+  
+  //UserActivityAgg
+  val scoreAggregateTag: OutputTag[Event] = OutputTag[Event]("score-aggregate-events")
+  val activityType = "activity_type"
+  val activityId = "activity_id"
+  val contextId = "context_id"
+  val activityUser = "user_id"
+  val aggLastUpdated = "agg_last_updated"
+  val agg = "agg"
 }

--- a/data-pipeline-flink/assessment-aggregator/src/main/scala/org/sunbird/dp/assessment/task/AssessmentAggregatorStreamTask.scala
+++ b/data-pipeline-flink/assessment-aggregator/src/main/scala/org/sunbird/dp/assessment/task/AssessmentAggregatorStreamTask.scala
@@ -6,10 +6,9 @@ import com.typesafe.config.ConfigFactory
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.TypeExtractor
 import org.apache.flink.api.java.utils.ParameterTool
-import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.sunbird.dp.assessment.domain.Event
-import org.sunbird.dp.assessment.functions.AssessmentAggregatorFunction
+import org.sunbird.dp.assessment.functions.{AssessmentAggregatorFunction, UserScoreAggregateFunction}
 import org.sunbird.dp.core.job.FlinkKafkaConnector
 import org.sunbird.dp.core.util.FlinkUtil
 
@@ -61,6 +60,8 @@ class AssessmentAggregatorStreamTask(config: AssessmentAggregatorConfig, kafkaCo
         aggregatorStream.getSideOutput(config.certIssueOutputTag).addSink(kafkaConnector.kafkaStringSink(config.kafkaCertIssueTopic))
           .name(config.certIssueEventSink).uid(config.certIssueEventSink)
           .setParallelism(config.downstreamOperatorsParallelism)
+        aggregatorStream.getSideOutput(config.scoreAggregateTag).process(new UserScoreAggregateFunction(config))
+          .name(config.userScoreAggregateFn).uid(config.userScoreAggregateFn).setParallelism(config.scoreAggregatorParallelism)
         env.execute(config.jobName)
     }
 }

--- a/data-pipeline-flink/assessment-aggregator/src/test/resources/test.conf
+++ b/data-pipeline-flink/assessment-aggregator/src/test/resources/test.conf
@@ -13,6 +13,9 @@ task {
   assessaggregator {
     parallelism = 1
   }
+  scoreaggregator {
+      parallelism = 1
+    }
   consumer.parallelism = 1
   downstream.parallelism = 1
 }
@@ -22,6 +25,7 @@ lms-cassandra {
   table = "assessment_aggregator"
   questionudttype= "question"
   enrolmentstable = "user_enrolments"
+  activitytable = "user_activity_agg"
 }
 
 redis {

--- a/data-pipeline-flink/assessment-aggregator/src/test/resources/test.cql
+++ b/data-pipeline-flink/assessment-aggregator/src/test/resources/test.cql
@@ -16,11 +16,11 @@ duration decimal
 
 
 CREATE TABLE IF NOT EXISTS sunbird_courses.assessment_aggregator (
+user_id text,
 course_id text,
 batch_id text,
 content_id text,
 attempt_id text,
-user_id text,
 created_on timestamp,
 last_attempted_on timestamp,
 total_max_score double,
@@ -28,7 +28,7 @@ grand_total text,
 question list<frozen<question>>,
 total_score double,
 updated_on timestamp,
-PRIMARY KEY (course_id, batch_id, content_id, attempt_id, user_id)
+PRIMARY KEY ((user_id, course_id), batch_id, content_id, attempt_id)
 );
 
 CREATE INDEX assessment_aggregator_last_attempted_on_idx ON sunbird_courses.assessment_aggregator (last_attempted_on);
@@ -61,3 +61,14 @@ PRIMARY KEY (userid, courseid, batchid));
 
 INSERT INTO sunbird_courses.user_enrolments(userid, courseid, batchid, status) VALUES ('ff1c4bdf-27e2-49bc-a53f-6e304bb3a87f', 'do_2128415652377067521125', '012846671379595264119', 2);
 INSERT INTO sunbird_courses.user_enrolments(userid, courseid, batchid, status) VALUES ('d0d8a341-9637-484c-b871-0c27015af238', 'do_2128410273679114241112', '01284169026368307244', 1);
+
+
+CREATE TABLE sunbird_courses.user_activity_agg (
+activity_type text,
+activity_id text,
+user_id text,
+context_id text,
+agg map<text, int>,
+agg_last_updated map<text, timestamp>,
+PRIMARY KEY ((activity_type, activity_id, user_id), context_id)
+) WITH CLUSTERING ORDER BY (context_id ASC);

--- a/kubernetes/ansible/roles/flink-jobs-deploy/defaults/main.yml
+++ b/kubernetes/ansible/roles/flink-jobs-deploy/defaults/main.yml
@@ -136,10 +136,12 @@ user_read_api_url : "http://{{private_ingressgateway_ip}}{{ user_read_api_endpoi
 assessaggregator_parallelism: 1
 assessaggregator_consumer_parallelism: 1
 assessaggregator_downstream_parallelism: 1
+assessaggregator_scoreaggregator_parallelism: 1
 middleware_cassandra_courses_keyspace: sunbird_courses
 middleware_cassandra_assessment_aggregator_table: assessment_aggregator
 middleware_cassandra_assessment_question_type : question
 middleware_cassandra_user_enrolments_table: user_enrolments
+middleware_cassandra_user_activity_agg_table: user_activity_agg
 
 ### taskmanager related vars
 healthcheck: true

--- a/kubernetes/helm_charts/datapipeline_jobs/values.j2
+++ b/kubernetes/helm_charts/datapipeline_jobs/values.j2
@@ -679,12 +679,14 @@ assessment-aggregator:
       assessaggregator {
         parallelism = {{ assessaggregator_parallelism }}
       }
+      scoreaggregator.parallelism = {{ assessaggregator_scoreaggregator_parallelism }}
     }
     lms-cassandra {
       keyspace = "{{ middleware_cassandra_courses_keyspace }}"
       table = "{{ middleware_cassandra_assessment_aggregator_table }}"
       questionudttype= "{{ middleware_cassandra_assessment_question_type }}"
       enrolmentstable = "{{ middleware_cassandra_user_enrolments_table }}"
+      activitytable = "{{ middleware_cassandra_user_activity_agg_table }}"
     }
     redis {
       database {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/SC-2218" title="SC-2218" target="_blank"><img alt="Story" src="https://project-sunbird.atlassian.net/secure/viewavatar?size=medium&avatarId=10315&avatarType=issuetype" />SC-2218</a>  Groups to report activity scores in addition to progress
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This PR includes changes to assessment-aggregator to populate best attempted scores in user_activity_agg. This is used in group aggregate API

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test update to user_activity_agg on successful updates to assessment-aggregator
- [x] Test metrics of UserScoreAggregateFn should be same as AssessmentAggregateFn
- [x] On Failed events in AssessmentAggregateFn, UserScoreAggregateFn is not invoked

**Test Configuration**:
* Software versions:
* Hardware versions:

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules