### PR TITLE
TG-934: Fix the consistency level in flink job

### DIFF
--- a/data-pipeline-flink/assessment-aggregator/src/main/scala/org/sunbird/dp/assessment/functions/AssessmentAggregatorFunction.scala
+++ b/data-pipeline-flink/assessment-aggregator/src/main/scala/org/sunbird/dp/assessment/functions/AssessmentAggregatorFunction.scala
@@ -169,7 +169,7 @@ class AssessmentAggregatorFunction(config: AssessmentAggregatorConfig,
     cassandraUtil.upsert(query)
     logger.info("Successfully Aggregated the batch event - batchid: "
       + batchEvent.batchId + " ,userid: " + batchEvent.userId + " ,couserid: "
-      + batchEvent.courseId + " ,contentid: " + batchEvent.contentId, "attempid" + batchEvent.attemptId)
+      + batchEvent.courseId + " ,contentid: " + batchEvent.contentId + "attempid" + batchEvent.attemptId)
   }
 
   def getQuestion(questionData: QuestionData, assessTs: Long): UDTValue = {

--- a/data-pipeline-flink/assessment-aggregator/src/test/scala/org/sunbird/dp/spec/AssessmentAggregatorTaskTestSpec.scala
+++ b/data-pipeline-flink/assessment-aggregator/src/test/scala/org/sunbird/dp/spec/AssessmentAggregatorTaskTestSpec.scala
@@ -1,7 +1,6 @@
 package org.sunbird.dp.spec
 
 import java.util
-
 import com.google.gson.Gson
 import com.typesafe.config.{Config, ConfigFactory}
 import org.apache.flink.api.common.typeinfo.TypeInformation
@@ -24,6 +23,7 @@ import org.sunbird.dp.core.util.{CassandraUtil, JSONUtil}
 import org.sunbird.dp.fixture.EventFixture
 import org.sunbird.dp.{BaseMetricsReporter, BaseTestSpec}
 import redis.embedded.RedisServer
+
 
 class AssessmentAggregatorTaskTestSpec extends BaseTestSpec {
 

--- a/data-pipeline-flink/dp-core/src/main/scala/org/sunbird/dp/core/util/CassandraUtil.scala
+++ b/data-pipeline-flink/dp-core/src/main/scala/org/sunbird/dp/core/util/CassandraUtil.scala
@@ -9,11 +9,12 @@ import org.slf4j.LoggerFactory
 class CassandraUtil(host: String, port: Int) {
 
   val logger = LoggerFactory.getLogger("CassandraUtil")
-
+  val options : QueryOptions = new QueryOptions()
   val cluster = {
     Cluster.builder()
       .addContactPoint(host)
       .withPort(port)
+      .withQueryOptions(options.setConsistencyLevel(ConsistencyLevel.QUORUM))
       .withoutJMXReporting()
       .build()
   }


### PR DESCRIPTION
This fix for the changing the default consistency level from LOCAL_ONE to QUORUM for cassandra dependency jobs

### Type of change

Please choose appropriate options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Ran all test cases with new consistency level

**Test Configuration**:
* Software versions:
* Hardware versions:

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules