### PR TITLE
SB-24258: Ansible changes for userRead API to take fields as organisations

### DIFF
--- a/data-pipeline-flink/user-cache-updater-2.0/src/main/resources/user-cache-updater-v2.conf
+++ b/data-pipeline-flink/user-cache-updater-2.0/src/main/resources/user-cache-updater-v2.conf
@@ -28,4 +28,4 @@ user.self.signin.types = ["google","self"]
 user.validated.types = ["sso"]
 user.self.signin.key = "Self-Signed-In"
 user.valid.key = "Validated"
-user.read.url.fields = "locations"
+user.read.url.fields = "locations,organisations"

--- a/data-pipeline-flink/user-cache-updater-2.0/src/test/resources/test.conf
+++ b/data-pipeline-flink/user-cache-updater-2.0/src/test/resources/test.conf
@@ -27,4 +27,4 @@ user.self.signin.types = ["google","self"]
 user.validated.types = ["sso"]
 user.self.signin.key = "Self-Signed-In"
 user.valid.key = "Validated"
-user.read.url.fields = "locations"
+user.read.url.fields = "locations,organisations"

--- a/kubernetes/helm_charts/datapipeline_jobs/values.j2
+++ b/kubernetes/helm_charts/datapipeline_jobs/values.j2
@@ -651,7 +651,7 @@ user-cache-updater-v2:
     user.validated.types = ["sso"]
     user.self.signin.key = "Self-Signed-In"
     user.valid.key = "Validated"
-    user.read.url.fields = "locations"
+    user.read.url.fields = "locations,organisations"
 
   flink-conf: |+
     jobmanager.memory.flink.size: {{ flink_job_names['user-cache-updater-v2'].jobmanager_memory }}


### PR DESCRIPTION
This fix is an ansible change to support organisations field for userReadAPI in user-cache-updater-v2 flink job

### Type of change

Please choose appropriate options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions:
* Hardware versions:

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules