### PR TITLE
TG-937: Ansible changes for guava jar dependency for HDInsights-4.0

### DIFF
--- a/ansible/roles/provision-azure-spark-cluster/defaults/main.yml
+++ b/ansible/roles/provision-azure-spark-cluster/defaults/main.yml
@@ -2,12 +2,12 @@ spark_folder: /usr/hdp/current/spark2-client
 guava_version: 19.0
 log4j_version: 2.5
 spark_redis_version: 2.5.0
-guava_default_gre_version: 28.0-jre
-guava_gre_version: 24.1.1-jre
+guava_default_jre_version: 28.0-jre
+guava_jre_version: 24.1.1-jre
 jedis_version: 3.2.0
 zip4j_version: 2.6.2
 guava_url: https://repo1.maven.org/maven2/com/google/guava/guava/{{guava_version}}/guava-{{guava_version}}.jar
-guava_jre_url: https://repo1.maven.org/maven2/com/google/guava/guava/{{guava_gre_version}}/guava-{{guava_gre_version}}.jar
+guava_jre_url: https://repo1.maven.org/maven2/com/google/guava/guava/{{guava_jre_version}}/guava-{{guava_jre_version}}.jar
 log4j_core_url: https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-core/{{log4j_version}}/log4j-core-{{log4j_version}}.jar
 log4j_api_url: https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-api/{{log4j_version}}/log4j-api-{{log4j_version}}.jar
 spark_redis_url: https://repo1.maven.org/maven2/com/redislabs/spark-redis_2.11/{{spark_redis_version}}/spark-redis_2.11-{{spark_redis_version}}.jar

--- a/ansible/roles/provision-azure-spark-cluster/defaults/main.yml
+++ b/ansible/roles/provision-azure-spark-cluster/defaults/main.yml
@@ -2,9 +2,12 @@ spark_folder: /usr/hdp/current/spark2-client
 guava_version: 19.0
 log4j_version: 2.5
 spark_redis_version: 2.5.0
+guava_default_gre_version: 28.0-jre
+guava_gre_version: 24.1.1-jre
 jedis_version: 3.2.0
 zip4j_version: 2.6.2
 guava_url: https://repo1.maven.org/maven2/com/google/guava/guava/{{guava_version}}/guava-{{guava_version}}.jar
+guava_jre_url: https://repo1.maven.org/maven2/com/google/guava/guava/{{guava_gre_version}}/guava-{{guava_gre_version}}.jar
 log4j_core_url: https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-core/{{log4j_version}}/log4j-core-{{log4j_version}}.jar
 log4j_api_url: https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-api/{{log4j_version}}/log4j-api-{{log4j_version}}.jar
 spark_redis_url: https://repo1.maven.org/maven2/com/redislabs/spark-redis_2.11/{{spark_redis_version}}/spark-redis_2.11-{{spark_redis_version}}.jar

--- a/ansible/roles/provision-azure-spark-cluster/tasks/main.yml
+++ b/ansible/roles/provision-azure-spark-cluster/tasks/main.yml
@@ -11,12 +11,12 @@
 - name: Remove guava-jre default jar
   become: yes
   file:
-    path: {{ spark_folder }}/jars/guava-{{guava_default_gre_version}}.jar
+    path: "{{ spark_folder }}/jars/guava-{{guava_default_jre_version}}.jar"
     state: absent
 
 - name: Download guava_jre_url and copy to Spark jars folder
   become: yes
-  get_url: url={{ guava_jre_url }} dest={{ spark_folder }}/jars/guava-{{guava_gre_version}}.jar timeout=1000 force=no
+  get_url: url={{ guava_jre_url }} dest={{ spark_folder }}/jars/guava-{{guava_jre_version}}.jar timeout=1000 force=no
   
 - name: Download log4j api and copy to Spark jars folder
   become: yes

--- a/ansible/roles/provision-azure-spark-cluster/tasks/main.yml
+++ b/ansible/roles/provision-azure-spark-cluster/tasks/main.yml
@@ -7,6 +7,16 @@
     - {var: 'azure_storage_key', value: '{{ sunbird_private_storage_account_name }}'}
     - {var: 'azure_storage_secret', value: '{{ sunbird_private_storage_account_key }}'}
   no_log: true
+
+- name: Remove guava-jre default jar
+  become: yes
+  file:
+    path: {{ spark_folder }}/jars/guava-{{guava_default_gre_version}}.jar
+    state: absent
+
+- name: Download guava_jre_url and copy to Spark jars folder
+  become: yes
+  get_url: url={{ guava_jre_url }} dest={{ spark_folder }}/jars/guava-{{guava_gre_version}}.jar timeout=1000 force=no
   
 - name: Download log4j api and copy to Spark jars folder
   become: yes


### PR DESCRIPTION
Provision ansible changes for removing the guava 28 jar which is having conflicts with jcloud  and replacing with guava 24 vesrion jar in hdinsigts 4.0 upgrade.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Done testing for all spark dependency jobs in loadtest enviroment with hdinsights-4.0

**Test Configuration**:
* Software versions:
* Hardware versions:

### Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules