### PR TITLE
TG-953 added the flink jobs log level control mechanism

### DIFF
--- a/kubernetes/ansible/roles/flink-jobs-deploy/defaults/main.yml
+++ b/kubernetes/ansible/roles/flink-jobs-deploy/defaults/main.yml
@@ -269,4 +269,4 @@ flink_job_names:
     cpu_requests: 0.3 
 
 ### controlling the flink jobs log level
-flink_jobs_log_level: ERROR
+flink_jobs_console_log_level: ERROR

--- a/kubernetes/ansible/roles/flink-jobs-deploy/defaults/main.yml
+++ b/kubernetes/ansible/roles/flink-jobs-deploy/defaults/main.yml
@@ -269,4 +269,5 @@ flink_job_names:
     cpu_requests: 0.3 
 
 ### controlling the flink jobs log level
+flink_jobs_console_log_level: INFO
 flink_libraries_log_level: ERROR

--- a/kubernetes/ansible/roles/flink-jobs-deploy/defaults/main.yml
+++ b/kubernetes/ansible/roles/flink-jobs-deploy/defaults/main.yml
@@ -269,4 +269,4 @@ flink_job_names:
     cpu_requests: 0.3 
 
 ### controlling the flink jobs log level
-flink_jobs_console_log_level: ERROR
+flink_libraries_log_level: ERROR

--- a/kubernetes/ansible/roles/flink-jobs-deploy/defaults/main.yml
+++ b/kubernetes/ansible/roles/flink-jobs-deploy/defaults/main.yml
@@ -267,3 +267,6 @@ flink_job_names:
     taskmanager_memory: 1024m
     taskslots: 1
     cpu_requests: 0.3 
+
+### controlling the flink jobs log level
+flink_jobs_log_level: ERROR

--- a/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_configmap.yaml
+++ b/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_configmap.yaml
@@ -10,3 +10,5 @@ data:
 {{ .Values.base_config | indent 4 }}
 {{- $name := .Release.Name }}
 {{ index .Values $name | toYaml | indent 2 }}
+  log4j_properties: |+
+{{ .Values.log4j_properties | indent 4 }}

--- a/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_configmap.yaml
+++ b/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_configmap.yaml
@@ -10,5 +10,5 @@ data:
 {{ .Values.base_config | indent 4 }}
 {{- $name := .Release.Name }}
 {{ index .Values $name | toYaml | indent 2 }}
-  log4j_properties: |+
-{{ .Values.log4j_properties | indent 4 }}
+  log4j_console_properties: |+
+{{ .Values.log4j_console_properties | indent 4 }}

--- a/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
+++ b/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
@@ -140,7 +140,7 @@ spec:
           mountPath: /data/flink/conf/{{ .Release.Name }}.conf
           subPath: {{ .Release.Name }}.conf
         - name: flink-config-volume
-          mountPath: /data/flink/conf/log4j-console.properties
+          mountPath: /opt/flink/conf/log4j-console.properties
           subPath: log4j-console.properties
 
 ---
@@ -201,5 +201,5 @@ spec:
           mountPath: /opt/flink/conf/flink-conf.yaml
           subPath: flink-conf.yaml
         - name: flink-config-volume
-          mountPath: /data/flink/conf/log4j-console.properties
+          mountPath: /opt/flink/conf/log4j-console.properties
           subPath: log4j-console.properties

--- a/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
+++ b/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
@@ -96,7 +96,7 @@ spec:
             path: base-config.conf
           - key: {{ .Release.Name }}
             path: {{ .Release.Name }}.conf
-          - key: log4j_properties
+          - key: log4j_console_properties
             path: log4j-console.properties
       restartPolicy: OnFailure
       imagePullSecrets:
@@ -168,7 +168,7 @@ spec:
           items:
           - key: flink-conf
             path: flink-conf.yaml
-          - key: log4j_properties
+          - key: log4j_console_properties
             path: log4j-console.properties 
       imagePullSecrets:
       - name: {{ .Values.imagepullsecrets }}

--- a/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
+++ b/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
@@ -96,6 +96,8 @@ spec:
             path: base-config.conf
           - key: {{ .Release.Name }}
             path: {{ .Release.Name }}.conf
+          - key: log4j_properties
+            path: log4j-console.properties
       restartPolicy: OnFailure
       imagePullSecrets:
       - name: {{ .Values.imagepullsecrets }}
@@ -137,6 +139,9 @@ spec:
         - name: flink-config-volume
           mountPath: /data/flink/conf/{{ .Release.Name }}.conf
           subPath: {{ .Release.Name }}.conf
+        - name: flink-config-volume
+          mountPath: /data/flink/conf/log4j-console.properties
+          subPath: log4j-console.properties
 
 ---
 apiVersion: apps/v1
@@ -163,6 +168,8 @@ spec:
           items:
           - key: flink-conf
             path: flink-conf.yaml
+          - key: log4j_properties
+            path: log4j-console.properties 
       imagePullSecrets:
       - name: {{ .Values.imagepullsecrets }}
       containers:
@@ -193,3 +200,6 @@ spec:
         - name: flink-config-volume
           mountPath: /opt/flink/conf/flink-conf.yaml
           subPath: flink-conf.yaml
+        - name: flink-config-volume
+          mountPath: /data/flink/conf/log4j-console.properties
+          subPath: log4j-console.properties

--- a/kubernetes/helm_charts/datapipeline_jobs/values.j2
+++ b/kubernetes/helm_charts/datapipeline_jobs/values.j2
@@ -46,13 +46,13 @@ log4j_console_properties: |
   # log level INFO. The root logger does not override this. You have to manually
   # change the log levels here.
   logger.akka.name = akka
-  logger.akka.level = {{ flink_jobs_console_log_level | default(INFO) }}
+  logger.akka.level = {{ flink_libraries_log_level | default(INFO) }}
   logger.kafka.name= org.apache.kafka
-  logger.kafka.level = {{ flink_jobs_console_log_level | default(INFO) }}
+  logger.kafka.level = {{ flink_libraries_log_level | default(INFO) }}
   logger.hadoop.name = org.apache.hadoop
-  logger.hadoop.level = {{ flink_jobs_console_log_level | default(INFO) }}
+  logger.hadoop.level = {{ flink_libraries_log_level | default(INFO) }}
   logger.zookeeper.name = org.apache.zookeeper
-  logger.zookeeper.level = {{ flink_jobs_console_log_level | default(INFO) }}
+  logger.zookeeper.level = {{ flink_libraries_log_level | default(INFO) }}
 
   # Log all infos to the console
   appender.console.name = ConsoleAppender

--- a/kubernetes/helm_charts/datapipeline_jobs/values.j2
+++ b/kubernetes/helm_charts/datapipeline_jobs/values.j2
@@ -33,6 +33,51 @@ taskmanager:
 job_classname: {{ job_classname }}
 {{ taskmanager_liveness | to_nice_yaml }}
 
+log4j_properties: |
+  # This affects logging for both user code and Flink
+  rootLogger.level = {{ flink_jobs_log_level | default(INFO) }}
+  rootLogger.appenderRef.console.ref = ConsoleAppender
+  rootLogger.appenderRef.rolling.ref = RollingFileAppender
+
+  # Uncomment this if you want to _only_ change Flink's logging
+  #logger.flink.name = org.apache.flink
+  #logger.flink.level = INFO
+
+  # The following lines keep the log level of common libraries/connectors on
+  # log level INFO. The root logger does not override this. You have to manually
+  # change the log levels here.
+  logger.akka.name = akka
+  logger.akka.level = INFO
+  logger.kafka.name= org.apache.kafka
+  logger.kafka.level = INFO
+  logger.hadoop.name = org.apache.hadoop
+  logger.hadoop.level = INFO
+  logger.zookeeper.name = org.apache.zookeeper
+  logger.zookeeper.level = INFO
+
+  # Log all infos to the console
+  appender.console.name = ConsoleAppender
+  appender.console.type = CONSOLE
+  appender.console.layout.type = PatternLayout
+  appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS} %-5p %-60c %x - %m%n
+
+  # Log all infos in the given rolling file
+  appender.rolling.name = RollingFileAppender
+  appender.rolling.type = RollingFile
+  appender.rolling.append = false
+  appender.rolling.fileName = ${sys:log.file}
+  appender.rolling.filePattern = ${sys:log.file}.%i
+  appender.rolling.layout.type = PatternLayout
+  appender.rolling.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS} %-5p %-60c %x - %m%n
+  appender.rolling.policies.type = Policies
+  appender.rolling.policies.size.type = SizeBasedTriggeringPolicy
+  appender.rolling.policies.size.size=100MB
+  appender.rolling.strategy.type = DefaultRolloverStrategy
+  appender.rolling.strategy.max = 10
+
+  # Suppress the irrelevant (wrong) warnings from the Netty channel handler
+  logger.netty.name = org.apache.flink.shaded.akka.org.jboss.netty.channel.DefaultChannelPipeline
+  logger.netty.level = OFF
 
 base_config: |
   kafka {

--- a/kubernetes/helm_charts/datapipeline_jobs/values.j2
+++ b/kubernetes/helm_charts/datapipeline_jobs/values.j2
@@ -33,47 +33,32 @@ taskmanager:
 job_classname: {{ job_classname }}
 {{ taskmanager_liveness | to_nice_yaml }}
 
-log4j_properties: |
+log4j_console_properties: |
   # This affects logging for both user code and Flink
-  rootLogger.level = {{ flink_jobs_log_level | default(INFO) }}
+  rootLogger.level = {{ flink_jobs_console_log_level | default(INFO) }}
   rootLogger.appenderRef.console.ref = ConsoleAppender
-  rootLogger.appenderRef.rolling.ref = RollingFileAppender
 
   # Uncomment this if you want to _only_ change Flink's logging
   #logger.flink.name = org.apache.flink
-  #logger.flink.level = INFO
+  #logger.flink.level = {{ flink_jobs_console_log_level | default(INFO) }}
 
   # The following lines keep the log level of common libraries/connectors on
   # log level INFO. The root logger does not override this. You have to manually
   # change the log levels here.
   logger.akka.name = akka
-  logger.akka.level = INFO
+  logger.akka.level = {{ flink_jobs_console_log_level | default(INFO) }}
   logger.kafka.name= org.apache.kafka
-  logger.kafka.level = INFO
+  logger.kafka.level = {{ flink_jobs_console_log_level | default(INFO) }}
   logger.hadoop.name = org.apache.hadoop
-  logger.hadoop.level = INFO
+  logger.hadoop.level = {{ flink_jobs_console_log_level | default(INFO) }}
   logger.zookeeper.name = org.apache.zookeeper
-  logger.zookeeper.level = INFO
+  logger.zookeeper.level = {{ flink_jobs_console_log_level | default(INFO) }}
 
   # Log all infos to the console
   appender.console.name = ConsoleAppender
   appender.console.type = CONSOLE
   appender.console.layout.type = PatternLayout
   appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS} %-5p %-60c %x - %m%n
-
-  # Log all infos in the given rolling file
-  appender.rolling.name = RollingFileAppender
-  appender.rolling.type = RollingFile
-  appender.rolling.append = false
-  appender.rolling.fileName = ${sys:log.file}
-  appender.rolling.filePattern = ${sys:log.file}.%i
-  appender.rolling.layout.type = PatternLayout
-  appender.rolling.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS} %-5p %-60c %x - %m%n
-  appender.rolling.policies.type = Policies
-  appender.rolling.policies.size.type = SizeBasedTriggeringPolicy
-  appender.rolling.policies.size.size=100MB
-  appender.rolling.strategy.type = DefaultRolloverStrategy
-  appender.rolling.strategy.max = 10
 
   # Suppress the irrelevant (wrong) warnings from the Netty channel handler
   logger.netty.name = org.apache.flink.shaded.akka.org.jboss.netty.channel.DefaultChannelPipeline


### PR DESCRIPTION
This PR is to control the log level for flink jobs. As part of this change we have introduced one ansible var **flink_jobs_log_level**. By using this var we can control the log level for flink jobs.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Depoyed in dev env and verified the logs.


**Test Configuration**:
* Software versions:
* Hardware versions:

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules