### PR TITLE
TG-905: Use supervisord to run anomaly_detection 

### DIFF
--- a/ansible/druid_anomaly_detection.yml
+++ b/ansible/druid_anomaly_detection.yml
@@ -1,5 +1,4 @@
 - hosts: spark
   become: yes
-  become_user: "{{ analytics_user }}"
   roles:
     - druid-anomaly-detection

--- a/ansible/roles/druid-anomaly-detection/defaults/main.yml
+++ b/ansible/roles/druid-anomaly-detection/defaults/main.yml
@@ -1,5 +1,6 @@
+supervisord_process_name: anomaly_detection
 anomaly_detection_module_artifact: anomaly_detection.tar.gz
-anomaly_detection_lib_path: /home/analytics/anomaly_detection
+anomaly_detection_module_path: /home/analytics/anomaly_detection
 virtualenv_path: /home/analytics/anomaly_detection/anomaly_venv
 anomaly_detection_job_config_file: "{{virtualenv_path}}/config.json"
 anomaly_detection_data_dir: "/home/analytics/anomaly_detection/data"

--- a/ansible/roles/druid-anomaly-detection/tasks/main.yml
+++ b/ansible/roles/druid-anomaly-detection/tasks/main.yml
@@ -1,5 +1,36 @@
 ---
 
+- name: Install supervisord
+  apt:
+    name: supervisor
+    state: present
+    update_cache: yes
+  become: true
+
+- name: Start supervisord
+  service:
+    name: "supervisor"
+    state: started
+    enabled: yes
+
+- name: copy supervisor conf
+  template: src="supervisor.conf.j2" dest="/etc/supervisor/conf.d/anomaly_detection.conf"
+  become: true
+
+- name: Add deadsnakes repo
+  apt_repository: repo="ppa:deadsnakes/ppa"
+  become: true
+
+- name: Install python
+  apt: 
+    name:
+      - python3.8-dev
+      - python3-pip
+      - python3-setuptools
+      - python3.8-venv
+    state: present
+  become: true
+
 - name: create module directories
   file:
     path: "{{ item }}"
@@ -10,22 +41,27 @@
   loop:
     - /home/analytics/anomaly_detection/anomaly_venv
     - /home/analytics/anomaly_detection/data
+  become_user: "{{ analytics_user }}"
 
 - name: Copy the anomaly detection artifact
-  copy: src={{ anomaly_detection_module_artifact }} dest={{ anomaly_detection_lib_path }}
+  copy: src={{ anomaly_detection_module_artifact }} dest={{ anomaly_detection_module_path }}
+  become_user: "{{ analytics_user }}"
 
-- name: Installing pip-3.8
+- name: Installing anomaly detection as a python module
   pip:
-    name: "{{ anomaly_detection_lib_path }}/{{ anomaly_detection_module_artifact }}"
+    name: "{{ anomaly_detection_module_path }}/{{ anomaly_detection_module_artifact }}"
     virtualenv: "{{ virtualenv_path }}"
-    virtualenv_python: "python3.8"
+    virtualenv_command: "/usr/bin/python3.8 -m venv"
+  become_user: "{{ analytics_user }}"
 
 - name: copy query config to config.json
   template: src="config.json.j2" dest="{{ virtualenv_path }}/config.json"
   with_items: "{{ anomaly_detection_queries | list }}"
+  become_user: "{{ analytics_user }}"
 
-- name: execute_anomaly_detection
-  shell: "source {{virtualenv_path}}/bin/activate && nohup anomaly_detection druid_anomaly_detection --config_file={{ anomaly_detection_job_config_file }} --data_dir={{ anomaly_detection_data_dir }} --druid_broker_host={{ sunbird_druid_broker_host }} --druid_broker_port=8082 &"
-  register: out
-  args:
-    executable: /bin/bash
+- name: Start anomaly detection process
+  supervisorctl:
+    name: "{{ supervisord_process_name }}"
+    state: present
+    config: "/etc/supervisor/conf.d/{{ supervisord_process_name }}.conf"
+  become: true

--- a/ansible/roles/druid-anomaly-detection/tasks/main.yml
+++ b/ansible/roles/druid-anomaly-detection/tasks/main.yml
@@ -7,14 +7,15 @@
     update_cache: yes
   become: true
 
+- name: copy supervisor conf
+  template: src="supervisor.conf.j2" dest="/etc/supervisor/conf.d/anomaly_detection.conf"
+  become: true
+
 - name: Start supervisord
   service:
     name: "supervisor"
     state: started
     enabled: yes
-
-- name: copy supervisor conf
-  template: src="supervisor.conf.j2" dest="/etc/supervisor/conf.d/anomaly_detection.conf"
   become: true
 
 - name: Add deadsnakes repo
@@ -61,7 +62,6 @@
 
 - name: Start anomaly detection process
   supervisorctl:
-    name: "{{ supervisord_process_name }}"
-    state: present
-    config: "/etc/supervisor/conf.d/{{ supervisord_process_name }}.conf"
+    name: "anomaly_detection"
+    state: restarted
   become: true

--- a/ansible/roles/druid-anomaly-detection/templates/supervisor.conf.j2
+++ b/ansible/roles/druid-anomaly-detection/templates/supervisor.conf.j2
@@ -1,15 +1,10 @@
 [program:{{ supervisord_process_name }}]
 process_name={{ supervisord_process_name }}
-command={{ virtualenv_path }}/anomaly_detection druid_anomaly_detection --config_file={{ anomaly_detection_job_config_file }} --data_dir="{{ anomaly_detection_data_dir }}" --druid_broker_host="{{ sunbird_druid_broker_host }}" --druid_broker_port=8082
+command={{ virtualenv_path }}/bin/anomaly_detection druid_anomaly_detection --config_file={{ anomaly_detection_job_config_file }} --data_dir="{{ anomaly_detection_data_dir }}" --druid_broker_host="{{ sunbird_druid_broker_host }}" --druid_broker_port=8082
 environment=PATH="{{ virtualenv_path }}/bin:%(ENV_PATH)s"
-user="{{ analytics_user }}"
-group="{{ analytics_user }}"
+user="{{analytics_user}}"
+group="{{analytics_user}}"
 killasgroup=true
 startsecs=5
 stopwaitsecs=5
 redirect_stderr=True
-stdout_logfile="{{ anomaly_detection_module_path }}/logs/anomaly_stdout.log"
-stderr_logfile="{{ anomaly_detection_module_path }}/logs/anomaly_stderr.log"
-
-[supervisorctl]
-serverurl=unix:///var/run/supervisor.sock

--- a/ansible/roles/druid-anomaly-detection/templates/supervisor.conf.j2
+++ b/ansible/roles/druid-anomaly-detection/templates/supervisor.conf.j2
@@ -1,0 +1,15 @@
+[program:{{ supervisord_process_name }}]
+process_name={{ supervisord_process_name }}
+command={{ virtualenv_path }}/anomaly_detection druid_anomaly_detection --config_file={{ anomaly_detection_job_config_file }} --data_dir="{{ anomaly_detection_data_dir }}" --druid_broker_host="{{ sunbird_druid_broker_host }}" --druid_broker_port=8082
+environment=PATH="{{ virtualenv_path }}/bin:%(ENV_PATH)s"
+user="{{ analytics_user }}"
+group="{{ analytics_user }}"
+killasgroup=true
+startsecs=5
+stopwaitsecs=5
+redirect_stderr=True
+stdout_logfile="{{ anomaly_detection_module_path }}/logs/anomaly_stdout.log"
+stderr_logfile="{{ anomaly_detection_module_path }}/logs/anomaly_stderr.log"
+
+[supervisorctl]
+serverurl=unix:///var/run/supervisor.sock


### PR DESCRIPTION
This PR includes the following changes:
1. Provision python 3.8 alongside existing 3.5 version. Also, set up python3-pip, python3-setuptools, python3.8-venv.
2. Install the anomaly_detection python module inside the virtualenv created.
3. Use supervisord to run anomaly_detection as a service.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

The ansible playbook has been tested in the loadtest environment and verified that the python3.8, venv and supervisord are installed as expected. The anomaly_detection module is installed and runs using the python scheduler to run the queries.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules