### PR TITLE
TG-979 - feature to deploy the ingestion spec into 2 different cluster

### DIFF
--- a/ansible/druid-ingestion.yml
+++ b/ansible/druid-ingestion.yml
@@ -1,6 +1,56 @@
 ---
-
-- hosts: "{{ cluster }}-overlord"
+- hosts: rollup-overlord
   become: yes
+  pre_tasks:
+   - name: set_fact
+     set_fact:
+       single_cluster: true
+     tags: populate_var
+
+   - name: check for hosts
+     set_fact:
+       single_cluster: false
+     when: "'rollup-overlord' in groups"
+     tags: populate_var
+
+   - name: debug
+     debug:
+       msg: "{{single_cluster}}"
+     tags: populate_var
   roles:
-     - druid-ingestion
+    - role: druid-ingestion
+      vars:
+        ingestion_task_names: "{{ rollup_vars }}"
+        overlord_host: "{{ rollup_overlord_host }}"
+      when: not single_cluster
+
+- hosts: raw-overlord
+  become: yes
+  pre_tasks:
+   - name: set_fact
+     set_fact:
+       single_cluster: true
+     tags: populate_var
+
+   - name: check for hosts
+     set_fact:
+       single_cluster: false
+     when: "'rollup-overlord' in groups"
+     tags: populate_var
+
+   - name: debug
+     debug:
+       msg: "{{single_cluster}}"
+     tags: populate_var
+
+  roles:
+    - role: druid-ingestion
+      vars:
+        ingestion_task_names: "{{ raw_vars }}"
+        overlord_host: "{{ raw_overlord_host }}"
+      when: not single_cluster
+    - role: druid-ingestion
+      vars:
+        ingestion_task_names: "{{ raw_vars }},{{ rollup_vars }}"
+        overlord_host: "{{ raw_overlord_host }}"
+      when: single_cluster

--- a/ansible/druid-ingestion.yml
+++ b/ansible/druid-ingestion.yml
@@ -20,7 +20,7 @@
   roles:
     - role: druid-ingestion
       vars:
-        ingestion_task_names: "{{ rollup_vars }}"
+        ingestion_task_names: "{{ rollup_ingestion_task_names }}"
         overlord_host: "{{ rollup_overlord_host }}"
       when: not single_cluster
 
@@ -46,11 +46,11 @@
   roles:
     - role: druid-ingestion
       vars:
-        ingestion_task_names: "{{ raw_vars }}"
+        ingestion_task_names: "{{ raw_ingestion_task_names }}"
         overlord_host: "{{ raw_overlord_host }}"
       when: not single_cluster
     - role: druid-ingestion
       vars:
-        ingestion_task_names: "{{ raw_vars }},{{ rollup_vars }}"
+        ingestion_task_names: "{{ raw_ingestion_task_names }},{{ rollup_ingestion_task_names }}"
         overlord_host: "{{ raw_overlord_host }}"
       when: single_cluster

--- a/ansible/druid-ingestion.yml
+++ b/ansible/druid-ingestion.yml
@@ -1,7 +1,6 @@
 ---
-- hosts: rollup-overlord
-  become: yes
-  pre_tasks:
+- hosts: localhost
+  tasks:
    - name: set_fact
      set_fact:
        single_cluster: true
@@ -13,44 +12,25 @@
      when: "'rollup-overlord' in groups"
      tags: populate_var
 
-   - name: debug
-     debug:
-       msg: "{{single_cluster}}"
-     tags: populate_var
+- hosts: rollup-overlord
+  become: yes
   roles:
     - role: druid-ingestion
       vars:
         ingestion_task_names: "{{ rollup_ingestion_task_names }}"
         overlord_host: "{{ rollup_overlord_host }}"
-      when: not single_cluster
+      when: not hostvars['localhost']['single_cluster']
 
 - hosts: raw-overlord
   become: yes
-  pre_tasks:
-   - name: set_fact
-     set_fact:
-       single_cluster: true
-     tags: populate_var
-
-   - name: check for hosts
-     set_fact:
-       single_cluster: false
-     when: "'rollup-overlord' in groups"
-     tags: populate_var
-
-   - name: debug
-     debug:
-       msg: "{{single_cluster}}"
-     tags: populate_var
-
   roles:
     - role: druid-ingestion
       vars:
         ingestion_task_names: "{{ raw_ingestion_task_names }}"
         overlord_host: "{{ raw_overlord_host }}"
-      when: not single_cluster
+      when: not hostvars['localhost']['single_cluster']
     - role: druid-ingestion
       vars:
         ingestion_task_names: "{{ raw_ingestion_task_names }},{{ rollup_ingestion_task_names }}"
         overlord_host: "{{ raw_overlord_host }}"
-      when: single_cluster
+      when: hostvars['localhost']['single_cluster']

--- a/ansible/inventory/env/group_vars/all.yml
+++ b/ansible/inventory/env/group_vars/all.yml
@@ -137,7 +137,8 @@ sunbird_es_host: "{{groups['core-es']| join(',')}}"
 single_node_es_host: "{{ groups['core-es'][0] }}"
 
 ### Druid related vars
-overlord_host: "{{ groups['raw-overlord'][0] }}"
+raw_overlord_host: "{{ groups['raw-overlord'][0] }}"
+rollup_overlord_host: "{{ groups['rollup-overlord'][0] }}"
 
 ### Datapipeline Custom monitoring related vars ###
 influxdb: "{{ groups['influxdb'][0] }}"

--- a/ansible/roles/druid-ingestion/tasks/main.yml
+++ b/ansible/roles/druid-ingestion/tasks/main.yml
@@ -5,7 +5,7 @@
   tags: start-task
 
 - name: Load the ingestion json
-  set_fact: {"{{ item }}_json":"{{ lookup('template', (cluster + '_' + item))}}"}
+  set_fact: {"{{ item }}_json":"{{ lookup('template', (item))}}"}
   with_items: "{{ ingestion_task_names.split(',')|list }}"
   tags: start-task
 

--- a/pipelines/ops/druid/Jenkinsfile.ingestion
+++ b/pipelines/ops/druid/Jenkinsfile.ingestion
@@ -26,21 +26,19 @@ node("ops-slave") {
                 jobName = sh(returnStdout: true, script: "echo $JOB_NAME").split('/')[-1].trim()
                 currentWs = sh(returnStdout: true, script: 'pwd').trim()
         // populating the vars for raw-overlord and rollup-overlord cluster respectively.
-                list_vars="$ingestion_task_names";
-                println(list_vars);
-                List<String> list_vars_array = list_vars.split(',');
-                List<String> rollup_vars = [], raw_vars = [];
-                list_vars_array.each {
+                task_names="${params.ingestion_task_names}";
+                println(task_names);
+                List<String> task_names_list = task_names.split(',');
+                List<String> rollup_task_names = [], raw_task_names = [];
+                task_names_list.each {
                     if(it.startsWith("rollup")) {
-                        rollup_vars.add(it);
+                        rollup_task_names.add(it);
                     }
                     else
-                       raw_vars.add(it);
+                        raw_task_names.add(it);
                 }
-                rollup_ingestion_task_names = rollup_vars.join(",");
-                raw_ingestion_task_names = raw_vars.join(",");
                 ansiblePlaybook = "${currentWs}/ansible/druid-ingestion.yml"
-                ansibleExtraArgs = "--extra-vars \"rollup_ingestion_task_names=$rollup_ingestion_task_names raw_ingestion_task_names=$raw_ingestion_task_names\" --tags populate_var,${params.action} --vault-password-file /var/lib/jenkins/secrets/vault-pass -vv"
+                ansibleExtraArgs = "--extra-vars \"rollup_ingestion_task_names=${rollup_task_names.join(",")} raw_ingestion_task_names=${raw_task_names.join(",")}\" --tags populate_var,${params.action} --vault-password-file /var/lib/jenkins/secrets/vault-pass -vv"
                 values.put('currentWs', currentWs)
                 values.put('env', envDir)
                 values.put('module', module)

--- a/pipelines/ops/druid/Jenkinsfile.ingestion
+++ b/pipelines/ops/druid/Jenkinsfile.ingestion
@@ -18,22 +18,6 @@ node("ops-slave") {
 
         }
 
-        stage('populate vars'){
-           list_vars="raw_a,raw_b,raw_b,rollup_a,rollup_b,rollup_c";
-           println(list_vars);
-           List<String> list_vars_array = list_vars.split(',');
-           List<String> rollup_vars = [], raw_vars = [];
-           list_vars_array.each {
-               if(it.startsWith("rollup")) {
-                   rollup_vars.add(it);
-               }
-               else
-                   raw_vars.add(it);
-           }
-           print(rollup_vars.join(","));
-           print(raw_vars.join(","));
-           }
-
         ansiColor('xterm') {
             stage('deploy'){
                 values = [:]
@@ -41,8 +25,22 @@ node("ops-slave") {
                 module = sh(returnStdout: true, script: "echo $JOB_NAME").split('/')[-2].trim()
                 jobName = sh(returnStdout: true, script: "echo $JOB_NAME").split('/')[-1].trim()
                 currentWs = sh(returnStdout: true, script: 'pwd').trim()
+        // populating the vars for raw-overlord and rollup-overlord cluster respectively.
+                list_vars="$ingestion_task_names";
+                println(list_vars);
+                List<String> list_vars_array = list_vars.split(',');
+                List<String> rollup_vars = [], raw_vars = [];
+                list_vars_array.each {
+                    if(it.startsWith("rollup")) {
+                        rollup_vars.add(it);
+                    }
+                    else
+                       raw_vars.add(it);
+                }
+                rollup_ingestion_task_names = rollup_vars.join(",");
+                raw_ingestion_task_names = raw_vars.join(",");
                 ansiblePlaybook = "${currentWs}/ansible/druid-ingestion.yml"
-                ansibleExtraArgs = "--extra-vars \"rollup_vars=$rollup_vars raw_vars=$raw_vars cluster=${params.cluster}\" --tags ${params.action} --vault-password-file /var/lib/jenkins/secrets/vault-pass -vv"
+                ansibleExtraArgs = "--extra-vars \"rollup_ingestion_task_names=$rollup_ingestion_task_names raw_ingestion_task_names=$raw_ingestion_task_names\" --tags populate_var,${params.action} --vault-password-file /var/lib/jenkins/secrets/vault-pass -vv"
                 values.put('currentWs', currentWs)
                 values.put('env', envDir)
                 values.put('module', module)

--- a/pipelines/ops/druid/Jenkinsfile.ingestion
+++ b/pipelines/ops/druid/Jenkinsfile.ingestion
@@ -18,6 +18,22 @@ node("ops-slave") {
 
         }
 
+        stage('populate vars'){
+           list_vars="raw_a,raw_b,raw_b,rollup_a,rollup_b,rollup_c";
+           println(list_vars);
+           List<String> list_vars_array = list_vars.split(',');
+           List<String> rollup_vars = [], raw_vars = [];
+           list_vars_array.each {
+               if(it.startsWith("rollup")) {
+                   rollup_vars.add(it);
+               }
+               else
+                   raw_vars.add(it);
+           }
+           print(rollup_vars.join(","));
+           print(raw_vars.join(","));
+           }
+
         ansiColor('xterm') {
             stage('deploy'){
                 values = [:]
@@ -26,7 +42,7 @@ node("ops-slave") {
                 jobName = sh(returnStdout: true, script: "echo $JOB_NAME").split('/')[-1].trim()
                 currentWs = sh(returnStdout: true, script: 'pwd').trim()
                 ansiblePlaybook = "${currentWs}/ansible/druid-ingestion.yml"
-                ansibleExtraArgs = "--extra-vars \"ingestion_task_names=${params.ingestion_task_names} cluster=${params.cluster}\" --tags ${params.action} --vault-password-file /var/lib/jenkins/secrets/vault-pass -vv"
+                ansibleExtraArgs = "--extra-vars \"rollup_vars=$rollup_vars raw_vars=$raw_vars cluster=${params.cluster}\" --tags ${params.action} --vault-password-file /var/lib/jenkins/secrets/vault-pass -vv"
                 values.put('currentWs', currentWs)
                 values.put('env', envDir)
                 values.put('module', module)


### PR DESCRIPTION
This PR includes the changes to deploy the ingestion spec into 2 different cluster by just selecting the ingestion spec name from jenkins job.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions:
* Hardware versions:

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules