### PR TITLE
TG-905: Remove ops-slave node config from druid ingestion deployments

### DIFF
--- a/pipelines/ops/druid/Jenkinsfile.druidingestionalert
+++ b/pipelines/ops/druid/Jenkinsfile.druidingestionalert
@@ -1,5 +1,5 @@
 @Library('deploy-conf') _
-node("ops-slave") {
+node() {
     try {
         String ANSI_GREEN = "\u001B[32m"
         String ANSI_NORMAL = "\u001B[0m"

--- a/pipelines/ops/druid/Jenkinsfile.druidsegmentalert
+++ b/pipelines/ops/druid/Jenkinsfile.druidsegmentalert
@@ -1,5 +1,5 @@
 @Library('deploy-conf') _
-node("ops-slave") {
+node() {
     try {
         String ANSI_GREEN = "\u001B[32m"
         String ANSI_NORMAL = "\u001B[0m"

--- a/pipelines/ops/druid/Jenkinsfile.ingestion
+++ b/pipelines/ops/druid/Jenkinsfile.ingestion
@@ -1,5 +1,5 @@
 @Library('deploy-conf') _
-node("ops-slave") {
+node() {
     try {
         String ANSI_GREEN = "\u001B[32m"
         String ANSI_NORMAL = "\u001B[0m"


### PR DESCRIPTION
This PR fixes the issue of automatically using the available Jenkins node i.e. master instead of running the deployments on ops-slave nodes.

### Type of change

Please choose appropriate options.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules