### PR TITLE
TG-905: Fix the rollup broker host ansible variable

### DIFF
--- a/ansible/roles/druid-anomaly-detection/defaults/main.yml
+++ b/ansible/roles/druid-anomaly-detection/defaults/main.yml
@@ -1,4 +1,4 @@
-druid_broker_host: "http://{{ groups['rollup-broker'][0] | default(groups['raw-broker'][0]) }}"
+rollup_druid_broker_host: "http://{{ groups['rollup-broker'][0] | default(groups['raw-broker'][0]) }}"
 supervisord_process_name: anomaly_detection
 anomaly_detection_module_artifact: anomaly_detection.tar.gz
 anomaly_detection_module_path: /home/analytics/anomaly_detection

--- a/ansible/roles/druid-anomaly-detection/templates/supervisor.conf.j2
+++ b/ansible/roles/druid-anomaly-detection/templates/supervisor.conf.j2
@@ -1,6 +1,6 @@
 [program:{{ supervisord_process_name }}]
 process_name={{ supervisord_process_name }}
-command={{ virtualenv_path }}/bin/anomaly_detection druid_anomaly_detection --config_file={{ anomaly_detection_job_config_file }} --data_dir="{{ anomaly_detection_data_dir }}" --druid_broker_host="{{ druid_broker_host }}" --druid_broker_port=8082
+command={{ virtualenv_path }}/bin/anomaly_detection druid_anomaly_detection --config_file={{ anomaly_detection_job_config_file }} --data_dir="{{ anomaly_detection_data_dir }}" --druid_broker_host="{{ rollup_druid_broker_host }}" --druid_broker_port=8082
 environment=PATH="{{ virtualenv_path }}/bin:%(ENV_PATH)s"
 user={{analytics_user}}
 group={{analytics_user}}


### PR DESCRIPTION
This PR fixes the issue with the druid_broker_host ansible variable which is being overridden in the private repo for DruidQueryProcessor functionality.

### Type of change

Please choose appropriate options.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

N/A

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules