### PR TITLE
SB-24793 feat: Inserting max_score values into activity_aggregate

### DIFF
--- a/data-pipeline-flink/assessment-aggregator/src/test/scala/org/sunbird/dp/spec/AssessmentAggregatorTaskTestSpec.scala
+++ b/data-pipeline-flink/assessment-aggregator/src/test/scala/org/sunbird/dp/spec/AssessmentAggregatorTaskTestSpec.scala
@@ -105,9 +105,22 @@ class AssessmentAggregatorTaskTestSpec extends BaseTestSpec {
     assert(test_row2.getDouble("total_max_score") == 4.0)
 
     val test_row3 = cassandraUtil.findOne("select agg from sunbird_courses.user_activity_agg where activity_type='Course' and activity_id='do_2128410273679114241112' and  user_id='d0d8a341-9637-484c-b871-0c27015af238'")
-    val resultMap = test_row3.getMap("agg", new TypeToken[String]() {}, new TypeToken[Integer]() {})
-    assert(null != resultMap)
-    assert(2 == resultMap.getOrDefault("score:do_2128373396098744321673", 0))
+    val resultMap3 = test_row3.getMap("agg", new TypeToken[String]() {}, new TypeToken[Integer]() {})
+    assert(null != resultMap3)
+    assert(2 == resultMap3.getOrDefault("score:do_2128373396098744321673", 0))
+    assert(2 == resultMap3.getOrDefault("max_score:do_2128373396098744321673", 0))
+
+    val test_row4 = cassandraUtil.findOne("select agg from sunbird_courses.user_activity_agg where activity_type='Course' and activity_id='do_2128415652377067521125' and  user_id='ff1c4bdf-27e2-49bc-a53f-6e304bb3a87f'")
+    val resultMap4 = test_row4.getMap("agg", new TypeToken[String]() {}, new TypeToken[Integer]() {})
+    assert(null != resultMap4)
+    assert(3 == resultMap4.getOrDefault("score:do_212686723743318016173", 0))
+    assert(4 == resultMap4.getOrDefault("max_score:do_212686723743318016173", 0))
+
+    val test_row5 = cassandraUtil.findOne("select agg from sunbird_courses.user_activity_agg where activity_type='Course' and activity_id='do_3129323995959541761169' and  user_id='50a9e3fc-d047-4fa5-a37b-67501b8933db'")
+    val resultMap5 = test_row5.getMap("agg", new TypeToken[String]() {}, new TypeToken[Integer]() {})
+    assert(null != resultMap5)
+    assert(1 == resultMap5.getOrDefault("score:do_3129323935897108481169", 0))
+    assert(1 == resultMap5.getOrDefault("max_score:do_3129323935897108481169", 0))
   }
 
   def testCassandraUtil(cassandraUtil: CassandraUtil): Unit = {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/SB-24793" title="SB-24793" target="_blank"><img alt="Story" src="https://project-sunbird.atlassian.net/secure/viewavatar?size=medium&avatarId=10315&avatarType=issuetype" />SB-24793</a>  Assessments Archival - Jobs Implementation and testing
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Currently, We are storing only the best score value in the activity aggregate this changes to insert the max_score value of the question along with best score value into the activity_agg Cassandra table `agg` column. 
Since to support as part of assessment data archival.

**Example** 
In agg column it will be having both max_score and best_score of the question
 `Map(score:do_212686723743318016173 -> 1, max_score:do_212686723743318016173 -> 2)`

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions:
* Hardware versions:

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules