### PR TITLE
TG-992: Update druid_version variable to 0.21.1

### DIFF
--- a/ansible/roles/analytics-druid/defaults/main.yml
+++ b/ansible/roles/analytics-druid/defaults/main.yml
@@ -5,8 +5,8 @@ zookeeper_group: "groups[{{ cluster }}-zookeeper]"
 
 druid_user: druid
 druid_directory: "/data"
-druid_version: "0.20.0"
-druid_url: "https://archive.apache.org/dist/druid/0.21.1/apache-druid-0.21.1-bin.tar.gz"
+druid_version: "0.21.1"
+druid_url: "https://archive.apache.org/dist/druid/{{druid_version}}/apache-druid-{{druid_version}}-bin.tar.gz"
 druid_folder: "{{ druid_directory }}/apache-druid-{{ druid_version }}"
 druid_symlink: "{{ druid_directory }}/druid"
 druid_path: "{{ druid_symlink }}/"


### PR DESCRIPTION
This PR fixes the issue with using the druid_version variable as part of the Druid artifact download URL

### Type of change

Please choose appropriate options.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update