### PR TITLE
Issue #SB-25755: Revert | Loggers added for denorm job to verify AUDIT events

### DIFF
--- a/data-pipeline-flink/de-normalization/src/main/scala/org/sunbird/dp/denorm/functions/DenormalizationWindowFunction.scala
+++ b/data-pipeline-flink/de-normalization/src/main/scala/org/sunbird/dp/denorm/functions/DenormalizationWindowFunction.scala
@@ -77,7 +77,6 @@ class DenormalizationWindowFunction(config: DenormalizationConfig)(implicit val 
                 if (summaryEventsList.contains(event.eid()) || !(event.eid().contains("SUMMARY") || config.eventsToskip.contains(event.eid()))) {
                     true
                 } else {
-                    logger.info(s"DenormWindowFunction::Event Skipped having mid:${event.mid()} in event: " + event)
                     metrics.incCounter(config.eventsSkipped)
                     false
                 }
@@ -107,7 +106,6 @@ class DenormalizationWindowFunction(config: DenormalizationConfig)(implicit val 
                 dialcodeDenormalization.denormalize(event, cacheData, metrics)
                 contentDenormalization.denormalize(event, cacheData, metrics)
                 locationDenormalization.denormalize(event, metrics)
-                logger.info(s"DenormWindowFunction::Final Event processed:${event.mid()} in event: " + event)
                 context.output(config.denormEventsTag, event)
         }
     }
@@ -128,7 +126,6 @@ class DenormalizationWindowFunction(config: DenormalizationConfig)(implicit val 
             val actorType = event.actorType()
 
             val contentIds = if (event.isValidEventForContentDenorm(config, objectId, objectType, event.eid())) {
-                logger.info(s"DenormWindowFunction::Event Valid For Content Denorm having mid:${event.mid()} in event: " + event)
                 contentMap.put(objectId, null)
                 val collectionId = if (event.checkObjectIdNotEqualsRollUpId(EventsPath.OBJECT_ROLLUP_L1)) {
                     collectionMap.put(event.objectRollUpl1ID(), null)
@@ -142,7 +139,6 @@ class DenormalizationWindowFunction(config: DenormalizationConfig)(implicit val 
 
                 Some((objectId, collectionId, l2RollupId))
             } else {
-                logger.info(s"DenormWindowFunction::Event not valid for Content Denorm having mid:${event.mid()} in event: " + event)
                 None
             }
 

--- a/data-pipeline-flink/de-normalization/src/main/scala/org/sunbird/dp/denorm/type/ContentDenormalization.scala
+++ b/data-pipeline-flink/de-normalization/src/main/scala/org/sunbird/dp/denorm/type/ContentDenormalization.scala
@@ -1,6 +1,5 @@
 package org.sunbird.dp.denorm.`type`
 
-import org.slf4j.LoggerFactory
 import org.sunbird.dp.core.domain.EventsPath
 import org.sunbird.dp.core.job.Metrics
 import org.sunbird.dp.denorm.domain.Event
@@ -9,13 +8,10 @@ import org.sunbird.dp.denorm.util.CacheResponseData
 
 class ContentDenormalization(config: DenormalizationConfig) {
 
-  private[this] val logger = LoggerFactory.getLogger(classOf[ContentDenormalization])
-
   def denormalize(event: Event, cacheData: CacheResponseData, metrics: Metrics) = {
     val objectType = event.objectType()
     val objectId = event.objectID()
     if (event.isValidEventForContentDenorm(config, objectId, objectType, event.eid())) {
-      logger.info(s"ContentDenormalization::Event Valid For Content Denorm having mid:${event.mid()} in event: " + event)
       metrics.incCounter(config.contentTotal)
       val contentData = cacheData.content.map(f => {
         (f._1.toLowerCase().replace("_", ""), f._2)
@@ -39,8 +35,6 @@ class ContentDenormalization(config: DenormalizationConfig) {
           (f._1.toLowerCase().replace("_", ""), f._2)
         }))
       }
-    } else {
-      logger.info(s"ContentDenormalization::Event Not Valid For Content Denorm having mid:${event.mid()} in event: " + event)
     }
   }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/SB-25755" title="SB-25755" target="_blank"><img alt="Bug" src="https://project-sunbird.atlassian.net/secure/viewavatar?size=medium&avatarId=10303&avatarType=issuetype" />SB-25755</a>  Collection Name is Missing for the "enrol-complete" in the "Audit Rollup" Events 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Reverts project-sunbird/sunbird-data-pipeline#1386