### PR TITLE
TG-982: Ansible role for deploying Apache Superset on Kubernetes

### DIFF
--- a/ansible/inventory/env/group_vars/all.yml
+++ b/ansible/inventory/env/group_vars/all.yml
@@ -76,6 +76,12 @@ postgres:
   db_port: 5432
   db_admin_user: analytics
   db_admin_password: "{{dp_vault_pgdb_admin_password}}"
+  superset:
+    db_username: "superset"
+    db_password: "{{ dp_vault_superset_db_password }}"
+    db_name: "superset_db"
+
+superset_admin_password: "{{ dp_vault_superset_ui_admin_password }}"
 
 postgres_address_space: 0.0.0.0/0 # Postgres trust address space
 

--- a/ansible/inventory/env/group_vars/all.yml
+++ b/ansible/inventory/env/group_vars/all.yml
@@ -78,10 +78,10 @@ postgres:
   db_admin_password: "{{dp_vault_pgdb_admin_password}}"
   superset:
     db_username: "superset"
-    db_password: "{{ dp_vault_superset_db_password }}"
+    db_password: "{{ dp_vault_superset_db_password | default('') }}"
     db_name: "superset_db"
 
-superset_admin_password: "{{ dp_vault_superset_ui_admin_password }}"
+superset_admin_password: "{{ dp_vault_superset_ui_admin_password | default('') }}"
 
 postgres_address_space: 0.0.0.0/0 # Postgres trust address space
 

--- a/kubernetes/ansible/roles/superset/defaults/main.yml
+++ b/kubernetes/ansible/roles/superset/defaults/main.yml
@@ -1,0 +1,25 @@
+superset_namespace: "superset-{{ env }}"
+imagepullsecrets: "{{ env }}-registry-secret"
+runAsUser: 1000
+# User ID directive. This user must have enough permissions to run the bootstrap script
+# Runn containers as root is not recommended in production. Change this to another UID - e.g. 1000 to be more secure
+replicas: 1
+configMountPath: "/etc/superset"
+extraConfigMountPath: "/app/configs"
+
+oauth:
+  enabled: false
+  client_id: "{{ google_oauth_clientid | default('') }}"
+  client_secret: "{{ google_oauth_client_secret | default('') }}"
+  email_whitelist_regex: ""
+  whitelist_domain: ""
+  user_registration_role: "Gamma"
+
+createAdmin: true
+
+adminUser:
+  username: "admin"
+  firstname: "Superset"
+  lastname: "Admin"
+  email: "admin@superset.com"
+  password: "{{ superset_admin_password }}"

--- a/kubernetes/ansible/roles/superset/defaults/main.yml
+++ b/kubernetes/ansible/roles/superset/defaults/main.yml
@@ -1,5 +1,7 @@
 superset_namespace: "superset-{{ env }}"
 imagepullsecrets: "{{ env }}-registry-secret"
+apache_superset_image: "amancevice/superset"
+apache_superset_image_version: "1.2.0"
 runAsUser: 1000
 # User ID directive. This user must have enough permissions to run the bootstrap script
 # Runn containers as root is not recommended in production. Change this to another UID - e.g. 1000 to be more secure

--- a/kubernetes/ansible/roles/superset/tasks/main.yml
+++ b/kubernetes/ansible/roles/superset/tasks/main.yml
@@ -1,0 +1,35 @@
+- name: Create superset_db database if not exists
+  postgresql_db: name="{{ postgres.superset.db_name }}" \
+            login_host="{{ postgres.db_url }}" \
+            port="{{ postgres.db_port }}" \
+            login_user="{{ postgres.db_admin_user }}" \
+            login_password="{{ postgres.db_admin_password }}" \
+            encoding='UTF-8' \
+            state=present
+
+- name: Create superset user if not exists
+  postgresql_user: name="{{ postgres.superset.db_username }}" \
+              password="{{ dp_vault_superset_postgress_pass }}" \
+              no_password_changes=true \
+              priv=ALL \
+              state=present \
+              login_host="{{ postgres.db_url }}" \
+              port="{{ postgres.db_port }}" \
+              login_user="{{ postgres.db_admin_user }}" \
+              login_password="{{ postgres.db_admin_password }}" \
+              db="{{ postgres.superset.db_name }}"
+
+- name: Download helm chart dependencies
+  shell: helm dependency update "{{ chart_path }}"
+
+- name: template values.yaml file
+  template:
+    src: "{{ chart_path }}/values.j2"
+    dest: "{{ chart_path }}/values.yaml"
+
+- name: remove the job.batch
+  shell: kubectl delete job.batch/superset-init-db -n {{ superset_namespace }}
+  ignore_errors: yes
+
+- name: helm upgrade
+  shell: helm upgrade --install superset "{{ chart_path }}" -n {{ superset_namespace }} --create-namespace

--- a/kubernetes/ansible/superset.yaml
+++ b/kubernetes/ansible/superset.yaml
@@ -1,0 +1,9 @@
+---
+- hosts: localhost
+  gather_facts: no
+  vars_files:
+    - "{{inventory_dir}}/secrets.yml"
+  environment:
+    KUBECONFIG: "{{ kubeconfig_path }}"
+  roles:
+    - superset

--- a/kubernetes/helm_charts/superset/.helmignore
+++ b/kubernetes/helm_charts/superset/.helmignore
@@ -1,0 +1,24 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+Chart.lock
+requirements.lock
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/kubernetes/helm_charts/superset/Chart.lock
+++ b/kubernetes/helm_charts/superset/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: redis
+  repository: https://charts.bitnami.com/bitnami
+  version: 12.3.3
+- name: postgresql
+  repository: https://charts.bitnami.com/bitnami
+  version: 10.2.0
+digest: sha256:51635f1352f64f364f1454e0c26ce3b22f7d85e5a7d3e940f8f8d0aed0f82534
+generated: "2021-08-17T15:20:27.029281275+05:30"

--- a/kubernetes/helm_charts/superset/Chart.yaml
+++ b/kubernetes/helm_charts/superset/Chart.yaml
@@ -1,0 +1,41 @@
+# apiVersion: v2
+# name: superset
+# description: A Helm chart for Apache Superset
+
+# # A chart can be either an 'application' or a 'library' chart.
+# #
+# # Application charts are a collection of templates that can be packaged into versioned archives
+# # to be deployed.
+# #
+# # Library charts provide useful utilities or functions for the chart developer. They're included as
+# # a dependency of application charts to inject those utilities and functions into the rendering
+# # pipeline. Library charts do not define any templates and therefore cannot be deployed.
+# type: application
+
+# # This is the chart version. This version number should be incremented each time you make changes
+# # to the chart and its templates, including the app version.
+# version: 1.0.0
+
+# # This is the version number of the application being deployed. This version number should be
+# # incremented each time you make changes to the application.
+# appVersion: 1.20
+
+
+apiVersion: v2
+appVersion: "1.0"
+description: Apache Superset is a modern, enterprise-ready business intelligence web application
+name: superset
+maintainers:
+  - name: craig-rueda
+    email: craig@craigrueda.com
+    url: https://github.com/craig-rueda
+version: 0.3.5
+dependencies:
+- name: redis
+  version: 12.3.3
+  repository: https://charts.bitnami.com/bitnami
+  condition: redis.enabled
+- name: postgresql
+  version: 10.2.0
+  repository: https://charts.bitnami.com/bitnami
+  condition: postgresql.enabled

--- a/kubernetes/helm_charts/superset/templates/_helpers.tpl
+++ b/kubernetes/helm_charts/superset/templates/_helpers.tpl
@@ -1,0 +1,105 @@
+{{/*
+
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+*/}}
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "superset.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "superset.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "superset.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "superset-config" }}
+import os
+from cachelib.redis import RedisCache
+
+def env(key, default=None):
+    return os.getenv(key, default)
+
+MAPBOX_API_KEY = env('MAPBOX_API_KEY', '')
+CACHE_CONFIG = {
+      'CACHE_TYPE': 'redis',
+      'CACHE_DEFAULT_TIMEOUT': 300,
+      'CACHE_KEY_PREFIX': 'superset_',
+      'CACHE_REDIS_HOST': env('REDIS_HOST'),
+      'CACHE_REDIS_PORT': env('REDIS_PORT'),
+      'CACHE_REDIS_PASSWORD': env('REDIS_PASSWORD'),
+      'CACHE_REDIS_DB': env('REDIS_DB', 1),
+}
+DATA_CACHE_CONFIG = CACHE_CONFIG
+
+SQLALCHEMY_DATABASE_URI = f"postgresql+psycopg2://{env('DB_USER')}:{env('DB_PASS')}@{env('DB_HOST')}:{env('DB_PORT')}/{env('DB_NAME')}"
+SQLALCHEMY_TRACK_MODIFICATIONS = True
+SECRET_KEY = env('SECRET_KEY', 'thisISaSECRET_1234')
+
+# Flask-WTF flag for CSRF
+WTF_CSRF_ENABLED = True
+# Add endpoints that need to be exempt from CSRF protection
+WTF_CSRF_EXEMPT_LIST = []
+# A CSRF token that expires in 1 year
+WTF_CSRF_TIME_LIMIT = 60 * 60 * 24 * 365
+class CeleryConfig(object):
+  BROKER_URL = f"redis://{env('REDIS_HOST')}:{env('REDIS_PORT')}/0"
+  CELERY_IMPORTS = ('superset.sql_lab', )
+  CELERY_RESULT_BACKEND = f"redis://{env('REDIS_HOST')}:{env('REDIS_PORT')}/0"
+  CELERY_ANNOTATIONS = {'tasks.add': {'rate_limit': '10/s'}}
+
+CELERY_CONFIG = CeleryConfig
+RESULTS_BACKEND = RedisCache(
+      host=env('REDIS_HOST'),
+      port=env('REDIS_PORT'),
+      key_prefix='superset_results'
+)
+
+{{ if .Values.configOverrides }}
+{{- $oauth_enabled := .Values.oauth_enabled -}}
+# Overrides
+{{- range $key, $value := .Values.configOverrides }}
+{{- if or (ne $key "oauth") (default $oauth_enabled false) }}
+# {{ $key }}
+{{ tpl $value $ }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- end }}

--- a/kubernetes/helm_charts/superset/templates/configmap-superset.yaml
+++ b/kubernetes/helm_charts/superset/templates/configmap-superset.yaml
@@ -1,0 +1,32 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+{{- if .Values.extraConfigs }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "superset.fullname" . }}-extra-config
+  labels:
+    app: {{ template "superset.name" . }}
+    chart: {{ template "superset.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+{{- range $path, $config := .Values.extraConfigs }}
+  {{ $path }}: |
+{{- tpl $config $ | nindent 4 -}}
+{{- end -}}
+{{- end -}}

--- a/kubernetes/helm_charts/superset/templates/deployment.yaml
+++ b/kubernetes/helm_charts/superset/templates/deployment.yaml
@@ -1,0 +1,128 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "superset.fullname" . }}
+  labels:
+    app: {{ template "superset.name" . }}
+    chart: {{ template "superset.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.supersetNode.deploymentAnnotations }}
+  annotations:
+    {{ toYaml .Values.supersetNode.deploymentAnnotations | nindent 4 }}
+{{- end }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "superset.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      annotations:
+        # Force reload on config changes
+        checksum/superset_config.py: {{ include "superset-config" . | sha256sum }}
+        checksum/superset_init.sh: {{ tpl .Values.init.initscript . | sha256sum }}
+        checksum/connections: {{ .Values.supersetNode.connections | toYaml | sha256sum }}
+        checksum/extraConfigs: {{ .Values.extraConfigs | toYaml | sha256sum }}
+        checksum/extraSecrets: {{ .Values.extraSecrets | toYaml | sha256sum }}
+        checksum/extraSecretEnv: {{ .Values.extraSecretEnv | toYaml | sha256sum }}
+        checksum/configOverrides: {{ .Values.configOverrides | toYaml | sha256sum }}
+        {{- if .Values.supersetNode.forceReload }}
+        # Optionally force the thing to reload
+        force-reload: {{ randAlphaNum 5 | quote }}
+        {{- end }}
+      {{- if .Values.supersetNode.podAnnotations }}
+        {{ toYaml .Values.supersetNode.podAnnotations | nindent 8 }}
+      {{- end }}
+      labels:
+        app: {{ template "superset.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      {{- if .Values.serviceAccountName }}
+      serviceAccountName: {{ .Values.serviceAccountName }}
+      {{- end }}
+      securityContext:
+        runAsUser: {{ .Values.runAsUser }}
+      {{- if .Values.supersetNode.initContainers }}
+      initContainers:
+      {{-  tpl (toYaml .Values.supersetNode.initContainers) . | nindent 6 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: {{  tpl (toJson .Values.supersetNode.command) . }}
+          env:
+            - name: "SUPERSET_PORT"
+              value: {{ .Values.service.port | quote}}
+          {{- if .Values.extraEnv }}
+            {{- range $key, $value := .Values.extraEnv }}
+            - name: {{ $key | quote}}
+              value: {{ $value | quote }}
+            {{- end }}
+          {{- end }}
+          envFrom:
+            - secretRef:
+                name: {{ tpl .Values.envFromSecret . | quote }}
+            {{- range .Values.envFromSecrets }}
+            - secretRef:
+                name: {{ tpl . $ | quote }}
+            {{- end }}
+          volumeMounts:
+            - name: superset-config
+              mountPath: {{ .Values.configMountPath | quote }}
+              readOnly: true
+          {{- if .Values.extraConfigs }}
+            - name: superset-extra-config
+              mountPath: {{ .Values.extraConfigMountPath | quote }}
+              readOnly: true
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+{{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
+      {{- end }}
+
+      volumes:
+        - name: superset-config
+          secret:
+            secretName: {{ tpl .Values.configFromSecret . }}
+        {{- if .Values.extraConfigs }}
+        - name: superset-extra-config
+          configMap:
+            name: {{ template "superset.fullname" . }}-extra-config
+        {{- end }}

--- a/kubernetes/helm_charts/superset/templates/ingress.yaml
+++ b/kubernetes/helm_charts/superset/templates/ingress.yaml
@@ -1,0 +1,56 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+{{ if .Values.ingress.enabled -}}
+{{- $fullName := include "superset.fullname" . -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app: {{ template "superset.name" . }}
+    chart: {{ template "superset.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: {{ $.Values.ingress.path }}
+            pathType: {{ $.Values.ingress.pathType }}
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: http
+  {{- end }}
+{{- end }}

--- a/kubernetes/helm_charts/superset/templates/init-job.yaml
+++ b/kubernetes/helm_charts/superset/templates/init-job.yaml
@@ -1,0 +1,80 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+{{- if .Values.init.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "superset.name" . }}-init-db
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+spec:
+  template:
+    metadata:
+      name: {{ template "superset.name" . }}-init-db
+    spec:
+      securityContext:
+        runAsUser: {{ .Values.runAsUser }}
+      {{- if .Values.init.initContainers }}
+      initContainers:
+      {{-  tpl (toYaml .Values.init.initContainers) . | nindent 6 }}
+      {{- end }}
+      containers:
+      - name: {{ template "superset.name" . }}-init-db
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        {{ if .Values.extraEnv }}
+        env:
+          {{- range $key, $value := .Values.extraEnv }}
+          - name: {{ $key | quote }}
+            value: {{ $value | quote }}
+          {{- end }}
+        {{- end }}
+        envFrom:
+          - secretRef:
+              name: {{ tpl .Values.envFromSecret . }}
+          {{- range .Values.envFromSecrets }}
+          - secretRef:
+              name: {{ tpl . $ }}
+          {{- end }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        volumeMounts:
+          - name: superset-config
+            mountPath: {{ .Values.configMountPath | quote }}
+            readOnly: true
+        {{- if .Values.extraConfigs }}
+          - name: superset-extra-config
+            mountPath: {{ .Values.extraConfigMountPath | quote }}
+            readOnly: true
+        {{- end }}
+        command: {{  tpl (toJson .Values.init.command) . }}
+        resources:
+{{ toYaml .Values.init.resources | indent 10 }}
+{{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
+      {{- end }}
+      volumes:
+        - name: superset-config
+          secret:
+            secretName: {{ tpl .Values.configFromSecret . }}
+        {{- if .Values.extraConfigs }}
+        - name: superset-extra-config
+          configMap:
+            name: {{ template "superset.fullname" . }}-extra-config
+        {{- end }}
+      restartPolicy: Never
+{{- end }}

--- a/kubernetes/helm_charts/superset/templates/secret-env.yaml
+++ b/kubernetes/helm_charts/superset/templates/secret-env.yaml
@@ -1,0 +1,39 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "superset.fullname" . }}-env
+  labels:
+    app: {{ template "superset.fullname" . }}
+    chart: {{ template "superset.chart" . }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+stringData:
+    REDIS_HOST: {{ tpl .Values.supersetNode.connections.redis_host . | quote }}
+    REDIS_PORT: {{ .Values.supersetNode.connections.redis_port | quote }}
+    DB_HOST: {{ tpl .Values.supersetNode.connections.db_host . | quote }}
+    DB_PORT: {{ .Values.supersetNode.connections.db_port | quote }}
+    DB_USER: {{ .Values.supersetNode.connections.db_user | quote }}
+    DB_PASS: {{ .Values.supersetNode.connections.db_pass | quote }}
+    DB_NAME: {{ .Values.supersetNode.connections.db_name | quote }}
+    {{- if .Values.extraSecretEnv }}
+    {{- range $key, $value := .Values.extraSecretEnv }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+    {{- end }}

--- a/kubernetes/helm_charts/superset/templates/secret-superset-config.yaml
+++ b/kubernetes/helm_charts/superset/templates/secret-superset-config.yaml
@@ -1,0 +1,40 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "superset.fullname" . }}-config
+  labels:
+    app: {{ template "superset.fullname" . }}
+    chart: {{ template "superset.chart" . }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+stringData:
+  superset_config.py: |
+{{- include "superset-config" . | nindent 4 }}
+  superset_init.sh: |
+{{- tpl .Values.init.initscript . | nindent 4 }}
+  superset_bootstrap.sh: |
+{{- tpl .Values.bootstrapScript . | nindent 4 }}
+
+{{- if .Values.extraSecrets }}
+{{- range $path, $config := .Values.extraSecrets }}
+  {{ $path }}: |
+{{- tpl $config $ | nindent 4 -}}
+{{- end -}}
+{{- end -}}

--- a/kubernetes/helm_charts/superset/templates/service.yaml
+++ b/kubernetes/helm_charts/superset/templates/service.yaml
@@ -1,0 +1,42 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "superset.fullname" . }}
+  labels:
+    app: {{ template "superset.name" . }}
+    chart: {{ template "superset.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- with .Values.service.annotations }}
+  annotations:
+{{- toYaml . | nindent 4 }}
+{{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ template "superset.name" . }}
+    release: {{ .Release.Name }}
+  {{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}

--- a/kubernetes/helm_charts/superset/values.j2
+++ b/kubernetes/helm_charts/superset/values.j2
@@ -1,0 +1,325 @@
+replicaCount: {{ replicas }}
+oauth_enabled: {{ oauth.enabled }}
+
+# Install additional packages and do any other bootstrap configuration in this script
+# For production clusters it's recommended to build own image with this step done in CI
+bootstrapScript: |
+  #!/bin/bash
+  #rm -rf /var/lib/apt/lists/* && \
+  pip install \
+    sqlalchemy==1.3.24 \
+    psycopg2==2.8.5 \
+    redis==3.2.1 && \
+  if [ ! -f ~/bootstrap ]; then echo "Running Superset with uid {{ runAsUser }}" > ~/bootstrap; fi
+
+## The name of the secret which we will use to generate a superset_config.py file
+## Note: this secret must have the key superset_config.py in it and can include other files as well
+##
+configFromSecret: '{{ "{{" }} template "superset.fullname" . {{ "}}" }}-config'
+
+## The name of the secret which we will use to populate env vars in deployed pods
+## This can be useful for secret keys, etc.
+##
+envFromSecret: '{{ "{{" }} template "superset.fullname" . {{ "}}" }}-env'
+## This can be a list of template strings
+envFromSecrets: []
+
+## Extra environment variables that will be passed into pods
+##
+extraEnv: {}
+  # Extend timeout to allow long running queries.
+  # GUNICORN_TIMEOUT: 300
+
+
+   # OAUTH_HOME_DOMAIN: ..
+  # # If a whitelist is not set, any address that can use your OAuth2 endpoint will be able to login.
+  # #   this includes any random Gmail address if your OAuth2 Web App is set to External.
+  # OAUTH_WHITELIST_REGEX: ...
+
+## Extra environment variables to pass as secrets
+##
+extraSecretEnv: {}
+  # MAPBOX_API_KEY: ...
+  # # Google API Keys: https://console.cloud.google.com/apis/credentials
+  # GOOGLE_KEY: ...
+  # GOOGLE_SECRET: ...
+
+extraConfigs: {}
+  # datasources-init.yaml: |
+  #     databases:
+  #     - allow_csv_upload: true
+  #       allow_ctas: true
+  #       allow_cvas: true
+  #       database_name: example-db
+  #       extra: "{\r\n    \"metadata_params\": {},\r\n    \"engine_params\": {},\r\n    \"\
+  #         metadata_cache_timeout\": {},\r\n    \"schemas_allowed_for_csv_upload\": []\r\n\
+  #         }"
+  #       sqlalchemy_uri: example://example-db.local
+  #       tables: []
+
+extraSecrets: {}
+
+# A dictionary of overrides to append at the end of superset_config.py - the name does not matter
+# WARNING: the order is not guaranteed
+configOverrides:
+  enable_feature_flags: |
+    FEATURE_FLAGS = {
+      "DASHBOARD_NATIVE_FILTERS": True,
+      "DASHBOARD_CROSS_FILTERS": True,
+      "DASHBOARD_NATIVE_FILTERS_SET": True,
+      "ENABLE_TEMPLATE_PROCESSING": True,
+    }
+
+  data_cache_config: |
+    DATA_CACHE_CONFIG = {
+      'CACHE_TYPE': 'redis',
+      'CACHE_DEFAULT_TIMEOUT': 600,
+      'CACHE_KEY_PREFIX': 'superset_',
+      'CACHE_REDIS_URL': 'redis://{{ "{{" }} template "superset.fullname" . {{ "}}" }}-redis-headless:6379/1'
+    }
+
+  sql_alchemy_config: |
+    SQLALCHEMY_DATABASE_URI = 'postgresql://{{ postgres.superset.db_username }}:{{ postgres.superset.db_password }}@{{ postgres.db_url }}/{{ postgres.superset.db_name }}'
+    SQLALCHEMY_TRACK_MODIFICATIONS = True
+    SECRET_KEY = 'thisISaSECRET_1234'
+
+  #map_box_key: |
+  #  MAPBOX_API_KEY=''
+
+  oauth: |
+    from flask_appbuilder.security.manager import (AUTH_DB, AUTH_OAUTH)
+    AUTH_TYPE = AUTH_OAUTH
+
+    OAUTH_PROVIDERS = [
+      {
+          "name": "google",
+          "whitelist": [ "{{ oauth.email_whitelist_regex }}" ],
+          "icon": "fa-google",
+          "token_key": "access_token",
+          "remote_app": {
+              "client_id": "{{ oauth.client_id }}",
+              "client_secret": "{{ oauth.client_secret }}",
+              "api_base_url": "https://www.googleapis.com/oauth2/v2/",
+              "client_kwargs": {"scope": "email profile"},
+              "request_token_url": None,
+              "access_token_url": "https://accounts.google.com/o/oauth2/token",
+              "authorize_url": "https://accounts.google.com/o/oauth2/auth",
+              "authorize_params": {"hd": "{{ oauth.whitelist_domain }}"}
+          }
+      }
+    ]
+    # Map Authlib roles to superset roles
+    AUTH_ROLE_ADMIN = 'Admin'
+    AUTH_ROLE_PUBLIC = 'Public'
+    # Will allow user self registration, allowing to create Flask users from Authorized User
+    AUTH_USER_REGISTRATION = True
+    # The default user self registration role
+    AUTH_USER_REGISTRATION_ROLE = "{{ oauth.user_registration_role }}"
+
+configMountPath: "/etc/superset"
+
+extraConfigMountPath: "/app/configs"
+
+image:
+  repository: amancevice/superset
+  tag: 1.2.0
+  pullPolicy: Never
+
+imagePullSecrets: []
+
+
+service:
+  type: LoadBalancer
+  port: 8088
+  annotations: ""
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+    ## Extend timeout to allow long running queries.
+    # nginx.ingress.kubernetes.io/proxy-connect-timeout: "300"
+    # nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
+    # nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
+  path: /
+  pathType: ImplementationSpecific
+  hosts:
+    - chart-example.local
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+##
+## Superset node configuration
+supersetNode:
+  connections:
+    redis_host: '{{ "{{" }} template "superset.fullname" . {{ "}}" }}-redis-headless'
+    redis_port: "6379"
+    db_host: "{{ postgres.db_url }}"
+    db_port: "{{ postgres.db_port }}"
+    db_user: "{{ postgres.superset.db_username }}"
+    db_pass: "{{ postgres.superset.db_password }}"
+    db_name: "{{ postgres.superset.db_name }}"
+  forceReload: false # If true, forces deployment to reload on each upgrade
+  initContainers:
+    - name: wait-for-postgres
+      image: busybox:latest
+      imagePullPolicy: IfNotPresent
+      envFrom:
+        - secretRef:
+            name: '{{ "{{" }} tpl .Values.envFromSecret . {{ "}}" }}'
+      command: [ "/bin/sh", "-c", "until nc -zv $DB_HOST $DB_PORT -w1; do echo 'waiting for db'; sleep 1; done" ]
+  ## Annotations to be added to supersetNode deployment
+  deploymentAnnotations: {}
+  ## Annotations to be added to supersetNode pods
+  podAnnotations: {}
+
+##
+## Init job configuration
+init:
+  # Configure resources
+  # Warning: fab command consumes a lot of ram and can
+  # cause the process to be killed due to OOM if it exceeds limit
+  resources: {}
+    # limits:
+    #   cpu:
+    #   memory:
+    # requests:
+    #   cpu:
+    #   memory:
+  command:
+    - "/bin/sh"
+    - "-c"
+    - ". {{ configMountPath }}/superset_bootstrap.sh; . {{ configMountPath }}/superset_init.sh"
+  enabled: true
+  createAdmin: {{ createAdmin }}
+  initContainers:
+    - name: wait-for-postgres
+      image: busybox:latest
+      imagePullPolicy: IfNotPresent
+      envFrom:
+        - secretRef:
+            name: '{{ "{{" }} tpl .Values.envFromSecret . {{ "}}" }}'
+      command: [ "/bin/sh", "-c", "until nc -zv $DB_HOST $DB_PORT -w1; do echo 'waiting for db'; sleep 1; done" ]
+  initscript: |-
+    #!/bin/sh
+    echo "Upgrading DB schema..."
+    superset db upgrade
+    echo "Initializing roles..."
+    superset init
+    {{ "{{" }} if .Values.init.createAdmin {{ "}}" }}
+    echo "Creating admin user..."
+    superset fab create-admin \
+                    --username {{ adminUser.username }} \
+                    --firstname {{ adminUser.firstname }} \
+                    --lastname {{ adminUser.lastname }} \
+                    --email {{ adminUser.email }} \
+                    --password {{ adminUser.password }} \
+                    || true
+    {{ "{{" }} end {{ "}}" }}
+    if [ -f "{{ extraConfigMountPath }}/import_datasources.yaml" ]; then
+      echo "Importing database connections.... "
+      superset import_datasources -p {{ extraConfigMountPath }}/import_datasources.yaml
+    fi
+
+## Configuration values for the Redis dependency.
+## ref: https://github.com/kubernetes/charts/blob/master/stable/redis/README.md
+redis:
+  ##
+  ## Use the redis chart dependency.
+  ## Set to false if bringing your own redis.
+  enabled: true
+  usePassword: false
+  ##
+  ## If you are bringing your own redis, you can set the host in redisHost.
+  ## redisHost:
+  ##
+  ## Redis password
+  ##
+  ## password: superset
+  ##
+  ## Master configuration
+  master:
+    ##
+    ## Image configuration
+    # image:
+      ##
+      ## docker registry secret names (list)
+      # pullSecrets: nil
+    ##
+    ## Configure persistance
+    persistence:
+      ##
+      ## Use a PVC to persist data.
+      enabled: false
+      ##
+      ## Persistant class
+      # storageClass: classname
+      ##
+      ## Access mode:
+      accessModes:
+      - ReadWriteOnce
+  ##
+  ## Disable cluster management by default.
+  cluster:
+    enabled: false
+
+##
+## Configuration values for the postgresql dependency.
+## ref: https://github.com/kubernetes/charts/blob/master/stable/postgresql/README.md
+postgresql:
+  ##
+  ## Use the PostgreSQL chart dependency.
+  ## Set to false if bringing your own PostgreSQL.
+  enabled: false
+  ##
+  ## If you are bringing your own PostgreSQL, you should set postgresHost and
+  ## also probably service.port, postgresqlUsername, postgresqlPassword, and postgresqlDatabase
+  ## postgresHost: "{{ postgres.db_url }}"
+  ##
+  ## PostgreSQL port
+  service:
+    port: 5432
+  ## PostgreSQL User to create.
+  postgresqlUsername: "{{ postgres.superset.db_username }}"
+  ##
+  ## PostgreSQL Password for the new user.
+  ## If not set, a random 10 characters password will be used.
+  postgresqlPassword: "{{ postgres.superset.db_password }}"
+  ##
+  ## PostgreSQL Database to create.
+  postgresqlDatabase: "{{ postgres.superset.db_name }}"
+  ##
+  ## Persistent Volume Storage configuration.
+  ## ref: https://kubernetes.io/docs/user-guide/persistent-volumes
+  persistence:
+    ##
+    ## Enable PostgreSQL persistence using Persistent Volume Claims.
+    enabled: false
+    ##
+    ## Persistant class
+    # storageClass: classname
+    ##
+    ## Access modes:
+    accessModes:
+      - ReadWriteOnce
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/kubernetes/helm_charts/superset/values.j2
+++ b/kubernetes/helm_charts/superset/values.j2
@@ -121,9 +121,9 @@ configMountPath: "/etc/superset"
 extraConfigMountPath: "/app/configs"
 
 image:
-  repository: amancevice/superset
-  tag: 1.2.0
-  pullPolicy: Never
+  repository: {{ apache_superset_image }}
+  tag: {{ apache_superset_image_version }}
+  pullPolicy: Always
 
 imagePullSecrets: []
 


### PR DESCRIPTION
This PR includes helm chart for deploying Apache Superset on Kubernetes. The helm chart has dependency with bitnami/redis helm chart. The helm chart requires postgres to be running external to the Kubernetes cluster. It also has configuration for turning on/off Google based OAUTH2 to authenticate users based on domains/whitelisted email ids.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

The helm chart has been tested by running the ansible role in a local Minikube Kubernetes cluster by configuring it to publish the configuration to an already existing Postgresql server.

**Test Configuration**:
* Software versions:
  - Kubernetes version: 1.19.4
  - Postgresql version: 13.3
  - amancevice/superset Docker image: 1.2.0
* Hardware versions:

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules