### PR TITLE
chore(ansible): change default admin zookeeper port to 9876

### DIFF
--- a/ansible/roles/zookeeper-upgrade/templates/zoo.cfg.j2
+++ b/ansible/roles/zookeeper-upgrade/templates/zoo.cfg.j2
@@ -3,6 +3,8 @@ dataDir={{ zookeeper_data_dir }}
 dataLogDir={{ zookeeper_data_dir }}
 clientPort={{ client_port }}
 initLimit={{ init_limit }}
+# Default 8080 port will conflict with tomcat
+admin.serverPort=9876
 syncLimit={{ sync_limit }}
 maxClientCnxns={{ maxclinetconnection_limit }}
 {% if zookeeper_group | length > 1 %}


### PR DESCRIPTION
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions:
* Hardware versions:

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules