### PR TITLE
Added kafka listener in server.properties

### DIFF
--- a/ansible/roles/ansible-kafka-upgrade/templates/server.properties.j2
+++ b/ansible/roles/ansible-kafka-upgrade/templates/server.properties.j2
@@ -6,6 +6,9 @@
   {%- if url_host == ansible_fqdn or url_host in ansible_all_ipv4_addresses -%}
 broker.id={{loop.index0 + 1}}
 
+# Kafka connection string
+advertised.listeners=PLAINTEXT://{% for host in groups['zookeeper'] %}{{ hostvars[host].inventory_hostname }}:{{kafka_port}}{% if not loop.last %},{% endif %}{% endfor %}
+
 ############################# Socket Server Settings #############################
 
 # The port the socket server listens on


### PR DESCRIPTION
Advertised listener added for kafka connectivity after bootstrap server connection is established.

Without the kafka listener, Pods under Flinkjobs and Secor were not able to connect to kafka consumer topics.

### Type of change

Please choose appropriate options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules